### PR TITLE
Add env and TOML-backed config system

### DIFF
--- a/.gestalt/plans/config-system.org
+++ b/.gestalt/plans/config-system.org
@@ -167,7 +167,7 @@
 :Done when: No automatic config file lookup is added, and docs/comments state the intended order for future callers.
 :END:
 
-* WIP [#B] Update documentation and automated coverage
+* DONE [#B] Update documentation and automated coverage
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Make the new config behavior discoverable and covered by deterministic CTest tests.
@@ -190,7 +190,7 @@
 :Done when: Existing CLI smoke tests still pass with the new config system.
 :END:
 
-** TODO [#B] Document environment variables and TOML examples
+** DONE [#B] Document environment variables and TOML examples
 :PROPERTIES:
 :Why: Users need to know the canonical lowercase key names, and maintainers need to know that TOML parsing is delegated to vendored `tomlc17` while HasciiCam intentionally accepts only flat config keys.
 :Change: Update `AGENTS.md` if useful for future LLM work, and update user-facing docs such as `doc/hasciicam.1` or a docs page if config behavior is exposed publicly. Show examples: `mode=html output_file=frame.html hasciicam`, `font_size=2 foreground=FFFFFF hasciicam -m html`, and a minimal TOML file with `mode = "text"`, `output_file = "hasciicam.asc"`, `device = "/dev/video0"`, `char_size = "80x25"`, `sdl_renderer = "software"`, and `sdl_vsync = "off"`. State that TOML load/save functions are internal unless a CLI `--config` option is added later. Document the vendored `tomlc17` source, license, and update path in the source tree rather than only in user docs.

--- a/.gestalt/plans/config-system.org
+++ b/.gestalt/plans/config-system.org
@@ -1,0 +1,207 @@
+#+TITLE: Config System
+#+SUBTITLE: Map every launch switch to small config variables with CLI, environment, and TOML support through tomlc17
+#+DATE: 2026-05-31
+#+KEYWORDS: config cli environment toml hasciicam
+
+* DONE [#A] Inventory current configurable behavior
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Produce one complete source of truth for every current HasciiCam option and runtime switch before changing parser behavior.
+:Notes: Challenge the first idea of only wrapping `getopt_long`: this would miss mode side effects, SDL variables, and action options such as help/version. Keep the inventory small and code-adjacent, not a generated schema framework.
+:END:
+
+** DONE [#A] Catalog all command-line options and parser side effects
+:PROPERTIES:
+:Why: The new config system must match existing behavior, including options that do not simply assign one field.
+:Change: Read `src/app/app_config.c` and list every option from `long_options`, `short_options`, `help_text`, and the `switch` in `hasciicam_config_parse`. Record the current behavior, default value, validation, and side effects for each option. Include `-h/--help`, `-H/--aahelp`, and `-v/--version` as launch actions even though they exit today. Include `-s/--size` as a contextual alias that becomes character size in HTML mode and pixel size in live/text mode. Include mode side effects where `--mode html` defaults `aafile` to `hasciicam.html` and `--mode text` defaults it to `hasciicam.asc`. Note that the current short option string contains `f:` and `Q:` without implemented switch cases; do not add behavior for them unless a matching existing user-facing option is found.
+:Tests: No code tests; this is design inventory. Verify by comparing the final inventory against `hasciicam -h` output and the current option arrays.
+:Done when: The implementation notes contain every current option, its variable name, default, accepted values, and current side effects.
+:END:
+
+** DONE [#A] Catalog non-CLI runtime switches already used by the app
+:PROPERTIES:
+:Why: The request includes other configurable switches, and SDL behavior is currently controlled through process environment variables set from config.
+:Change: Inspect `src/hasciicam.c`, `src/aalib/aasdl.c`, and adjacent app/session modules for runtime switches outside normal CLI parsing. Include `HASCIICAM_SDL_RENDERER`, `HASCIICAM_SDL_VSYNC`, and `HASCIICAM_SDL_FULLSCREEN` as config-backed variables because the app already bridges them. Distinguish runtime config from CMake build options such as `HASCIICAM_ENABLE_SDL`; build options are not launch-time variables and should not be loaded from user TOML.
+:Tests: No code tests. Verify with `rg -n "getenv|setenv|SetEnvironmentVariable|HASCIICAM_" src include`.
+:Done when: The inventory explicitly states which switches are runtime config and which are compile-time build toggles excluded from launch config.
+:END:
+
+** DONE [#B] Choose final variable names and aliases
+:PROPERTIES:
+:Why: Variable names must be short, predictable, and valid across CLI, environment, and TOML sources.
+:Change: Define a table of canonical config keys using one or two words, three only when needed, all lowercase words separated by underscores. Use these keys for TOML and environment variables. Proposed canonical keys: `show_help`, `show_aahelp`, `show_version`, `quiet`, `mode`, `device`, `input`, `size`, `pixel_size`, `char_size`, `output_file`, `aa_driver`, `daemon`, `font_size`, `font_face`, `refresh`, `aa_bright`, `aa_contrast`, `aa_gamma`, `invert`, `background`, `foreground`, `uid`, `gid`, `frames`, `sdl_renderer`, `sdl_vsync`, `fullscreen`, `mirror`, plus derived/internal fields `size_intent`, `line_space`, `explicit_size`, and `explicit_driver`. Prefer `output_file` as the config key while keeping `--aafile` as the compatibility CLI spelling. Prefer `aa_driver` as the key while keeping `--aadriver`. Prefer `frames` over `max_frames` because it matches launch wording and is shorter.
+:Tests: No code tests. Review every key against the naming rule: one or two words by default, maximum three when needed, underscores only.
+:Done when: A checked-in comment or developer note near the config table shows the command-line option, environment/TOML key, struct field, parser, and default for every variable.
+:END:
+
+* DONE [#A] Build a table-driven config core
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Centralize config defaults, parsing, validation, and serialization metadata without introducing a large abstraction layer.
+:Notes: Keep this in the app slice. The simplest viable shape is a small descriptor table plus plain C helper functions in `src/app/app_config.*`. Do not introduce a generic reflection system.
+:END:
+
+** DONE [#A] Add config variable descriptors
+:PROPERTIES:
+:Why: One descriptor table prevents CLI, environment, and TOML support from drifting apart.
+:Change: Add a static table in `src/app/app_config.c` or a small new `src/app/app_config_vars.c` if the file becomes too large. Each row should contain canonical key, value type, target field offset or setter callback, default string or default callback, validation parser, and flags for serialize/load. Use callbacks for variables with side effects: `mode`, `size`, `pixel_size`, `char_size`, `font_size`, `sdl_vsync`, `sdl_renderer`, `mirror`, `show_help`, `show_aahelp`, and `show_version`. Keep simple ints and strings as direct setters when validation is trivial.
+:Tests: Add a plain C unit test executable if none already covers config parsing directly. Test descriptor lookup for a few known keys and that every command-line option has a descriptor or an explicit launch-action descriptor.
+:Done when: There is one authoritative descriptor table covering all keys from the inventory, and existing defaults still initialize to the same values.
+:END:
+
+** DONE [#A] Preserve current defaults and mode side effects
+:PROPERTIES:
+:Why: Config refactoring should not change startup behavior.
+:Change: Keep `hasciicam_config_init_defaults` as the single default initializer. Move repeated default values into descriptor defaults only if it keeps the code clearer. Ensure non-Windows device defaults still choose `/dev/video` when present and `/dev/video0` otherwise. Ensure `mode=html` assigns `output_file=hasciicam.html` only when the output file was not explicitly set by a higher-precedence source. Ensure `mode=text` assigns `output_file=hasciicam.asc` only when not explicit. Track explicitness with small flags such as `explicit_output`, `explicit_size`, and `explicit_driver`.
+:Tests: Add config tests for default live mode, default device behavior where practical, `mode=html` output default, `mode=text` output default, and explicit output overriding mode defaults.
+:Done when: A default config produces the same runtime values as before, and tests prove mode/output precedence.
+:END:
+
+** DONE [#A] Normalize parser functions by value type
+:PROPERTIES:
+:Why: Environment and TOML inputs need the same validation rules as CLI options.
+:Change: Extract reusable setters for boolean, integer, bounded integer when needed, string copy, mode, `WxH` sizes, SDL vsync, SDL renderer, mirror axis, and color strings. For booleans accept `1`, `0`, `true`, `false`, `yes`, `no`, `on`, and `off` where appropriate. Keep `sdl_vsync` special because it also accepts `auto`. Preserve current permissive integer behavior only where required, but prefer clear errors for invalid new env/TOML values.
+:Tests: Unit test accepted and rejected values for booleans, `mode`, `size`, `sdl_vsync`, `sdl_renderer`, and `mirror`.
+:Done when: CLI, environment, and TOML setters call the same validation helpers instead of duplicating parsing logic.
+:END:
+
+** DONE [#B] Add config error reporting helpers
+:PROPERTIES:
+:Why: Existing CLI errors print and exit; env/TOML loaders should report which key failed without spreading `fprintf` calls everywhere.
+:Change: Add a small `hasciicam_config_error` struct or callback-free helper that formats messages like `invalid value for sdl_vsync: expected on, off, or auto`. Keep CLI behavior as print-to-stderr then exit for invalid launch options. Make internal TOML load functions return an error code and optional message buffer instead of exiting.
+:Tests: Unit test one invalid CLI-style setter and one invalid TOML-style load path.
+:Done when: Invalid values are reported with key names and expected values, and internal load functions do not terminate the process.
+:END:
+
+* DONE [#A] Wire launch-time precedence for environment and CLI
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Let every config variable be set at launch from environment variables and command-line options, while keeping command-line options highest precedence.
+:Notes: Use lowercase environment variable names exactly matching canonical keys, as requested: for example `mode=html`, `font_size=2`, and `sdl_vsync=off`. This is unusual on Windows and Unix, but it is the requested contract. Do not add uppercase aliases unless explicitly requested later.
+:END:
+
+** DONE [#A] Load environment variables after defaults
+:PROPERTIES:
+:Why: Environment variables should provide launch defaults without overriding explicit CLI options.
+:Change: Add `hasciicam_config_load_env(hasciicam_config *cfg, char *err, size_t err_size)`. Iterate the descriptor table and call `getenv(key)` for each canonical key. If the variable exists and is non-empty, parse and apply it through the descriptor setter. Treat empty environment variables as unset to avoid accidental blank strings. Record explicitness for values supplied by env so mode side effects do not overwrite `output_file`, `size`, or driver choices unintentionally.
+:Tests: Add config unit tests that set temporary environment variables for `mode`, `output_file`, `font_size`, `invert`, `sdl_vsync`, and `char_size`, then verify resulting fields. Restore the previous process environment after each test.
+:Done when: Every descriptor can be loaded from a lowercase environment variable and invalid env values produce a readable launch error.
+:END:
+
+** DONE [#A] Keep command-line options as highest precedence
+:PROPERTIES:
+:Why: Users expect explicit CLI arguments to override environment defaults.
+:Change: Refactor `hasciicam_config_parse` so each option delegates to the same descriptor setters used by env/TOML. Call order at launch should become defaults, environment, then command-line. Preserve AA-lib parsing order outside this function as it exists today. Preserve `-h`, `-H`, and `-v` behavior by setting launch-action variables and then executing those actions after parsing enough context to print the same output. If keeping immediate exits is much simpler, document that these three action options are represented in the table but still exit immediately.
+:Tests: Add tests where env sets `mode=html` and CLI sets `--mode text`; env sets `font_size=4` and CLI sets `--font-size 2`; env sets `output_file=env.html` and CLI sets `-o cli.html`. Existing CLI smoke tests must still pass.
+:Done when: CLI values consistently override environment values, and current help/version behavior remains user-compatible.
+:END:
+
+** DONE [#B] Decide and document option aliases
+:PROPERTIES:
+:Why: CLI option names are historical while config keys should be clearer and shorter.
+:Change: Keep existing command-line spellings for compatibility: `--aafile`, `--aadriver`, `--pixel-size`, `--char-size`, `--font-size`, `--font-face`, `--sdl-renderer`, `--sdl-vsync`. Do not add new CLI aliases unless tests or documentation show a strong need. Environment and TOML use canonical names: `output_file`, `aa_driver`, `pixel_size`, `char_size`, `font_size`, `font_face`, `sdl_renderer`, and `sdl_vsync`.
+:Tests: Existing CLI tests prove old spellings still work. Add env/TOML tests proving canonical names work.
+:Done when: Backward-compatible CLI spellings and canonical config keys are both documented.
+:END:
+
+** DONE [#B] Apply SDL environment bridge from config once
+:PROPERTIES:
+:Why: SDL currently reads `HASCIICAM_SDL_RENDERER`, `HASCIICAM_SDL_VSYNC`, and `HASCIICAM_SDL_FULLSCREEN`; the new env contract uses lowercase config variables instead.
+:Change: Keep the existing bridge in `src/hasciicam.c` or move it to a clearly named helper. It should translate config fields into the existing `HASCIICAM_SDL_*` process variables before SDL initializes. Do not require users to set `HASCIICAM_SDL_*` directly. If both old `HASCIICAM_SDL_*` and new lowercase config variables are present, prefer the config field because it can come from CLI or lowercase env.
+:Tests: Add or update an SDL-related smoke test only if it can run headless/deterministically. Otherwise unit test the bridge helper by checking process environment values after applying a config.
+:Done when: `sdl_renderer`, `sdl_vsync`, and `fullscreen` work from CLI and lowercase env without changing SDL driver internals.
+:END:
+
+* DONE [#A] Add TOML load and save functions with tomlc17
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Provide internal config file helpers that use the vendored `cktan/tomlc17` C parser for TOML reading and a small flat writer for TOML saving.
+:Notes: This is internal API, not a new launch feature unless requested later. The dependency is explicitly requested: vendor only the C header/source needed by `tomlc17`, keep it statically built in the app source slice, and avoid wrapping it in a broad config framework.
+:END:
+
+** DONE [#A] Vendor tomlc17 into the app source slice
+:PROPERTIES:
+:Why: The plan should use the requested TOML implementation rather than a custom parser, while keeping HasciiCam buildable without system packages.
+:Change: Copy `tomlc17.h` and `tomlc17.c` from `https://github.com/cktan/tomlc17` into a local source-slice directory such as `src/app/tomlc17/` or `src/app/config/tomlc17/`. Include the upstream MIT license text or copyright notice in a local `LICENSE.tomlc17`/comment according to the library license. Record the upstream commit or release tag in a short comment or `README` near the vendored files so future updates are auditable. Do not vendor the C++ wrapper, tests, examples, or Makefile unless they are needed.
+:Tests: Configure and build after adding the files. Verify the vendored header is included through a local path and no external TOML package is required.
+:Done when: The repository contains the `tomlc17` C header/source, license notice, and source provenance, and the build can compile them statically.
+:END:
+
+** DONE [#A] Add tomlc17 to CMake statically
+:PROPERTIES:
+:Why: The parser must be included in the build without adding runtime or system dependencies.
+:Change: Add the vendored `tomlc17.c` to the appropriate target source list, preferably `hasciicam_core` if TOML load/save functions live in the app/config code. Add the vendored include directory privately to the target that needs it. Keep compiler options local if the third-party code needs warning suppression; do not lower warning quality for HasciiCam sources. Confirm `tomlc17` is C-compatible in the current build modes and does not force C++.
+:Tests: Run `cmake --build build` or configure/build if the build tree does not exist.
+:Done when: `tomlc17.c` is compiled into HasciiCam targets that use config file support, with no system TOML dependency.
+:END:
+
+** DONE [#A] Define internal file API
+:PROPERTIES:
+:Why: Tests and future embedding code need stable functions without exposing unnecessary parser details.
+:Change: Add declarations in `src/app/app_config.h`: `int hasciicam_config_load_toml(hasciicam_config *cfg, const char *path, char *err, size_t err_size);` and `int hasciicam_config_save_toml(const hasciicam_config *cfg, const char *path, char *err, size_t err_size);`. If direct file IO in tests is awkward, also add string helpers with internal linkage or test-only exposure: parse from `toml_datum_t`/`FILE *` and write to `FILE *`.
+:Tests: Build tests must include the new declarations from C and compile without warnings.
+:Done when: Internal callers can load and save config files through small C functions that return success/failure instead of exiting.
+:END:
+
+** DONE [#A] Implement TOML loading through tomlc17
+:PROPERTIES:
+:Why: Using the requested library avoids maintaining custom TOML parsing code and gives clear syntax errors from a tested parser.
+:Change: In `hasciicam_config_load_toml`, call `toml_parse_file_ex(path)`, check `result.ok`, and always call `toml_free(result)` before returning. Iterate the top-level table (`result.toptab.u.tab`) and reject nested tables, arrays, dates, times, floats, and unknown keys because HasciiCam config is still a flat canonical key list. Accept TOML strings for string/enum/size fields, TOML integers for integer fields, and TOML booleans for boolean fields. For convenience, also allow strings for all values so examples like `font_size = "2"` still pass through the shared setter. Convert each accepted TOML datum into the same string/setter path used by CLI/env where practical, or call typed setters that share validation. Include `datum.lineno`/`datum.colno` in errors when available.
+:Tests: Unit test a file containing strings, integers, booleans, TOML comments, whitespace, `size = "80x25"`, `mode = "html"`, and `sdl_vsync = "auto"`. Unit test unknown key, invalid value, malformed TOML syntax reported by `tomlc17`, nested table rejection, array rejection, float rejection, and date/time rejection.
+:Done when: Loading a flat TOML file parsed by `tomlc17` updates the config through the same validation paths as other sources, and unsupported TOML structures fail with clear errors.
+:END:
+
+** DONE [#A] Implement the TOML writer
+:PROPERTIES:
+:Why: Saving config should round-trip current values and provide users a readable example file.
+:Change: Use a small HasciiCam writer rather than expecting `tomlc17` to encode output; the library is a parser. Write only canonical keys that represent persisted config values. Exclude transient launch actions `show_help`, `show_aahelp`, and `show_version`. Include derived fields only if they are user meaningful; prefer writing `pixel_size` or `char_size` based on `size_intent` rather than raw `size_intent`, `explicit_size`, or `line_space`. Quote strings and escape backslash, quote, newline, tab, and other control characters needed for valid TOML basic strings. Write booleans as bare TOML booleans, integers as bare integers, and enum-like values such as `mode`, `sdl_vsync`, and `mirror` as quoted strings.
+:Tests: Unit test save then load round-trip for a representative config. Verify the saved file contains canonical keys and no historical CLI names such as `aafile` or `aadriver`.
+:Done when: A saved config can be loaded back into an equivalent `hasciicam_config` for all persisted user-facing variables.
+:END:
+
+** DONE [#B] Keep TOML precedence internal and explicit
+:PROPERTIES:
+:Why: The request asks for internal load/save functions, not automatic startup file discovery.
+:Change: Do not auto-load `~/.hasciicam.toml`, current-directory files, or platform config directories. Document that callers may choose the order explicitly. Recommended future launch order, if a `--config` option is later requested, would be defaults, config file, environment, command-line.
+:Tests: No runtime tests beyond ensuring current CLI startup does not read files unexpectedly.
+:Done when: No automatic config file lookup is added, and docs/comments state the intended order for future callers.
+:END:
+
+* WIP [#B] Update documentation and automated coverage
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Make the new config behavior discoverable and covered by deterministic CTest tests.
+:Notes: Documentation should help users without expanding scope. Keep examples short and use existing option names plus canonical config keys.
+:END:
+
+** DONE [#A] Add focused config unit tests
+:PROPERTIES:
+:Why: This change affects launch behavior and needs deterministic coverage without camera or display dependencies.
+:Change: Add a plain C test target under the existing CMake/CTest setup, for example `config_parse`. Cover defaults, CLI parsing, environment parsing, CLI-over-env precedence, mode/output side effects, size intent, invalid values, TOML load, and TOML save/load round-trip. Keep generated TOML files in the build tree. Use process env carefully so tests do not leak variables across cases.
+:Tests: Run `cmake --build build` and `ctest --output-on-failure --test-dir build -R config`.
+:Done when: Config behavior has direct unit coverage and does not rely only on CLI smoke tests.
+:END:
+
+** DONE [#A] Keep existing CLI smoke tests passing
+:PROPERTIES:
+:Why: Existing smoke tests protect compatibility for users and packaging scripts.
+:Change: Run the current CLI tests after refactoring. Update tests only when they assert implementation details that intentionally changed; do not change user-facing command behavior casually. Include `hasciicam -h` and `hasciicam -H` because help and AA-help option parsing are special action paths.
+:Tests: Run `ctest --output-on-failure --test-dir build -L cli`, plus direct `build/hasciicam -h` and `build/hasciicam -H` when the executable path is available.
+:Done when: Existing CLI smoke tests still pass with the new config system.
+:END:
+
+** TODO [#B] Document environment variables and TOML examples
+:PROPERTIES:
+:Why: Users need to know the canonical lowercase key names, and maintainers need to know that TOML parsing is delegated to vendored `tomlc17` while HasciiCam intentionally accepts only flat config keys.
+:Change: Update `AGENTS.md` if useful for future LLM work, and update user-facing docs such as `doc/hasciicam.1` or a docs page if config behavior is exposed publicly. Show examples: `mode=html output_file=frame.html hasciicam`, `font_size=2 foreground=FFFFFF hasciicam -m html`, and a minimal TOML file with `mode = "text"`, `output_file = "hasciicam.asc"`, `device = "/dev/video0"`, `char_size = "80x25"`, `sdl_renderer = "software"`, and `sdl_vsync = "off"`. State that TOML load/save functions are internal unless a CLI `--config` option is added later. Document the vendored `tomlc17` source, license, and update path in the source tree rather than only in user docs.
+:Tests: No automated doc tests unless the repository already has them. Man page formatting should be checked if the toolchain is available.
+:Done when: The docs list canonical config keys and explain CLI/env/TOML scope without implying unsupported auto-loading.
+:END:
+
+** DONE [#B] Run full verification before final commits
+:PROPERTIES:
+:Why: Config parsing touches startup and tests across CLI modes.
+:Change: After all L2 implementation commits are complete, run the normal project verification: configure/build with CMake and Ninja, run all CTest tests, run `hasciicam -h`, and run `hasciicam -H` because AA-lib option ordering must remain intact.
+:Tests: `cmake --build build`, `ctest --output-on-failure --test-dir build`, `build/hasciicam -h`, and `build/hasciicam -H`. On Windows, use the configured build directory and executable path.
+:Done when: Build, full tests, help, and AA-help pass or any platform limitation is documented in the reviewer summary.
+:END:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,8 @@ The current path in `src/hasciicam.c` is:
 The CLI is defined in `src/hasciicam.c` by `long_options`, `short_options`, and
 the help string.
 
+Config parsing and normalization now live in `src/app/app_config.c`.
+
 Core options:
 
 - `-h`, `--help`: HasciiCam help.
@@ -158,6 +160,47 @@ Rendering options:
 
 AA-lib also parses its own options before HasciiCam parses its options. When
 changing CLI parsing, preserve that ordering.
+
+## Launch Configuration
+
+HasciiCam launch config supports three sources:
+
+1. Defaults from `hasciicam_config_init_defaults()`
+2. Lowercase environment variables with canonical config-key names
+3. Command-line options (highest precedence)
+
+Canonical config keys:
+
+- `quiet`
+- `mode`
+- `device`
+- `input`
+- `pixel_size`
+- `char_size`
+- `output_file`
+- `aa_driver`
+- `daemon`
+- `font_size`
+- `font_face`
+- `refresh`
+- `aa_bright`
+- `aa_contrast`
+- `aa_gamma`
+- `invert`
+- `background`
+- `foreground`
+- `uid`
+- `gid`
+- `frames`
+- `sdl_renderer`
+- `sdl_vsync`
+- `fullscreen`
+- `mirror`
+
+Compatibility note:
+
+- CLI names remain historical (`--aafile`, `--aadriver`) while env/TOML use
+  canonical names (`output_file`, `aa_driver`).
 
 Size intent and negotiation:
 
@@ -301,6 +344,17 @@ In `TEXT` mode:
 
 The save driver writes from AA-lib `textbuffer` and `attrbuffer`, so file output
 and live output share the same render stage.
+
+## TOML Config API
+
+Internal config file APIs are declared in `src/app/app_config.h`:
+
+- `hasciicam_config_load_toml(...)`
+- `hasciicam_config_save_toml(...)`
+
+TOML parsing uses vendored `cktan/tomlc17` source in `src/app/tomlc17/`.
+Current startup does not auto-load a TOML file and does not implement CLI
+`--config` discovery.
 
 ## Portability Notes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,10 @@ add_library(hasciicam_core STATIC
     ${HASCIICAM_OUTPUT_SOURCES}
     ${HASCIICAM_RENDER_SOURCES}
     ${HASCIICAM_CAPTURE_SOURCES}
+    src/app/tomlc17/tomlc17.c
 )
 target_include_directories(hasciicam_core PUBLIC include)
+target_include_directories(hasciicam_core PRIVATE src/app)
 if(HASCIICAM_ENABLE_CAPTURE_AVFOUNDATION)
   target_sources(hasciicam_core PRIVATE src/capture/capture_avfoundation.mm)
 endif()
@@ -241,6 +243,20 @@ if(HASCIICAM_ENABLE_TESTS)
   target_include_directories(test_app_size PRIVATE src/app)
   add_test(NAME app_size COMMAND test_app_size)
   set_tests_properties(app_size PROPERTIES LABELS "unit;core")
+
+  add_executable(test_app_config
+    tests/test_app_config.c
+    src/app/app_config.c
+    src/app/tomlc17/tomlc17.c
+  )
+  target_include_directories(test_app_config PRIVATE src/app)
+  if(WIN32)
+    target_sources(test_app_config PRIVATE src/compat/getopt.c)
+    target_include_directories(test_app_config PRIVATE src/compat)
+    target_compile_definitions(test_app_config PRIVATE _CRT_SECURE_NO_WARNINGS)
+  endif()
+  add_test(NAME app_config COMMAND test_app_config)
+  set_tests_properties(app_config PROPERTIES LABELS "unit;core")
 
   add_executable(test_capture_size
     tests/test_capture_size.c

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -83,6 +83,9 @@ Use \fB--mirror -x\fP to disable horizontal mirroring, and \fB--mirror y\fP to a
 .IP "-o --aafile"
 Defines the file where to save rendered ascii, overwrited every \fIrefresh\fP seconds. Default is \fBhasciicam.html\fP when in \fBhtml\fP mode, \fBhasciicam.txt\fP when in \fBtext\fP mode (useless when in \fBlive\fP mode).
 .B
+.IP "--frames"
+Stops after \fBN\fP rendered frames. Useful for deterministic smoke tests.
+.B
 .IP "-f --ftp"
 Ftp pushes the selected output file to an ftp account specified within an expression like \fB:user%pass@dyne.org:/home/user/www\fP. If the password is not specified (omit %pass) hasciicam asks for it on stdin (hidden while typing). If the directory is not specified it is assumed to be the first ftp directory where user logs in. Remote file is refreshed depending on \fBrefresh\fP rate and connection bandwidth, a \fIscolopendro\fP temporary file is created to keep clients on the other side refreshing smooth.
 .B
@@ -128,6 +131,43 @@ puts your ascii into your local .plan (fingercam)
 .B hasciicam -m html -S 2 -o index.html -f :jaromil%sasuchen@dyne.org:korova
 .br
 generates an hascii video with font size +1 and uploads the frames in ftp passive mode on the dyne.org server, with user jaromil password sasuchen, inside the korova directory
+.SH ENVIRONMENT
+HasciiCam also accepts launch configuration from lowercase environment
+variables that match canonical config keys. Command-line options have higher
+precedence than environment variables.
+.IP
+Examples:
+.br
+\fBmode=html\fP
+.br
+\fBoutput_file=frame.html\fP
+.br
+\fBfont_size=2\fP
+.br
+\fBsdl_renderer=software\fP
+.br
+\fBsdl_vsync=off\fP
+.IP
+Canonical keys:
+.br
+\fBquiet mode device input pixel_size char_size output_file aa_driver daemon\fP
+.br
+\fBfont_size font_face refresh aa_bright aa_contrast aa_gamma invert\fP
+.br
+\fBbackground foreground uid gid frames sdl_renderer sdl_vsync fullscreen mirror\fP
+.SH CONFIG FILES
+Internal APIs can load/save TOML config files using the vendored
+\fBcktan/tomlc17\fP parser. Current CLI startup does not auto-load TOML.
+.IP
+Example TOML:
+.nf
+mode = "text"
+output_file = "hasciicam.asc"
+device = "/dev/video0"
+char_size = "80x25"
+sdl_renderer = "software"
+sdl_vsync = "off"
+.fi
 .SH NOTES
 When using a usb webcam, a supported size needs to be specified. The minimum or maximum detected size should work, also a size of 160x120 mostly gives good results, with unsupported sizes you will get unexpected results.
 .SH BUGS

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -81,7 +81,7 @@ Horizontal mirror \fBx\fP is enabled by default so live preview behaves like a m
 Use \fB--mirror -x\fP to disable horizontal mirroring, and \fB--mirror y\fP to add vertical mirroring.
 .B
 .IP "-o --aafile"
-Defines the file where to save rendered ascii, overwrited every \fIrefresh\fP seconds. Default is \fBhasciicam.html\fP when in \fBhtml\fP mode, \fBhasciicam.txt\fP when in \fBtext\fP mode (useless when in \fBlive\fP mode).
+Defines the file where to save rendered ascii, overwrited every \fIrefresh\fP seconds. Default is \fBhasciicam.html\fP when in \fBhtml\fP mode, \fBhasciicam.asc\fP when in \fBtext\fP mode (useless when in \fBlive\fP mode).
 .B
 .IP "--frames"
 Stops after \fBN\fP rendered frames. Useful for deterministic smoke tests.

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -1,6 +1,7 @@
 #include "app_config.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +39,7 @@ typedef struct config_key_desc {
     const char *key;
     config_value_kind kind;
     int persist;
+    int allow_env_toml;
 } config_key_desc;
 
 static const struct option long_options[] = {
@@ -110,35 +112,35 @@ static const char *help_text =
     " -F --foreground   foreground color (hex)    - default 00FF00\n";
 
 static const config_key_desc config_keys[] = {
-    {"show_help", CONFIG_VALUE_BOOL, 0},
-    {"show_aahelp", CONFIG_VALUE_BOOL, 0},
-    {"show_version", CONFIG_VALUE_BOOL, 0},
-    {"quiet", CONFIG_VALUE_BOOL, 1},
-    {"mode", CONFIG_VALUE_MODE, 1},
-    {"device", CONFIG_VALUE_STRING, 1},
-    {"input", CONFIG_VALUE_INT, 1},
-    {"size", CONFIG_VALUE_SIZE, 0},
-    {"pixel_size", CONFIG_VALUE_PIXEL_SIZE, 1},
-    {"char_size", CONFIG_VALUE_CHAR_SIZE, 1},
-    {"output_file", CONFIG_VALUE_STRING, 1},
-    {"aa_driver", CONFIG_VALUE_STRING, 1},
-    {"daemon", CONFIG_VALUE_BOOL, 1},
-    {"font_size", CONFIG_VALUE_INT, 1},
-    {"font_face", CONFIG_VALUE_STRING, 1},
-    {"refresh", CONFIG_VALUE_INT, 1},
-    {"aa_bright", CONFIG_VALUE_INT, 1},
-    {"aa_contrast", CONFIG_VALUE_INT, 1},
-    {"aa_gamma", CONFIG_VALUE_INT, 1},
-    {"invert", CONFIG_VALUE_BOOL, 1},
-    {"background", CONFIG_VALUE_STRING, 1},
-    {"foreground", CONFIG_VALUE_STRING, 1},
-    {"uid", CONFIG_VALUE_INT, 1},
-    {"gid", CONFIG_VALUE_INT, 1},
-    {"frames", CONFIG_VALUE_INT, 1},
-    {"sdl_renderer", CONFIG_VALUE_SDL_RENDERER, 1},
-    {"sdl_vsync", CONFIG_VALUE_SDL_VSYNC, 1},
-    {"fullscreen", CONFIG_VALUE_BOOL, 1},
-    {"mirror", CONFIG_VALUE_MIRROR, 1}
+    {"show_help", CONFIG_VALUE_BOOL, 0, 0},
+    {"show_aahelp", CONFIG_VALUE_BOOL, 0, 0},
+    {"show_version", CONFIG_VALUE_BOOL, 0, 0},
+    {"quiet", CONFIG_VALUE_BOOL, 1, 1},
+    {"mode", CONFIG_VALUE_MODE, 1, 1},
+    {"device", CONFIG_VALUE_STRING, 1, 1},
+    {"input", CONFIG_VALUE_INT, 1, 1},
+    {"size", CONFIG_VALUE_SIZE, 0, 0},
+    {"pixel_size", CONFIG_VALUE_PIXEL_SIZE, 1, 1},
+    {"char_size", CONFIG_VALUE_CHAR_SIZE, 1, 1},
+    {"output_file", CONFIG_VALUE_STRING, 1, 1},
+    {"aa_driver", CONFIG_VALUE_STRING, 1, 1},
+    {"daemon", CONFIG_VALUE_BOOL, 1, 1},
+    {"font_size", CONFIG_VALUE_INT, 1, 1},
+    {"font_face", CONFIG_VALUE_STRING, 1, 1},
+    {"refresh", CONFIG_VALUE_INT, 1, 1},
+    {"aa_bright", CONFIG_VALUE_INT, 1, 1},
+    {"aa_contrast", CONFIG_VALUE_INT, 1, 1},
+    {"aa_gamma", CONFIG_VALUE_INT, 1, 1},
+    {"invert", CONFIG_VALUE_BOOL, 1, 1},
+    {"background", CONFIG_VALUE_STRING, 1, 1},
+    {"foreground", CONFIG_VALUE_STRING, 1, 1},
+    {"uid", CONFIG_VALUE_INT, 1, 1},
+    {"gid", CONFIG_VALUE_INT, 1, 1},
+    {"frames", CONFIG_VALUE_INT, 1, 1},
+    {"sdl_renderer", CONFIG_VALUE_SDL_RENDERER, 1, 1},
+    {"sdl_vsync", CONFIG_VALUE_SDL_VSYNC, 1, 1},
+    {"fullscreen", CONFIG_VALUE_BOOL, 1, 1},
+    {"mirror", CONFIG_VALUE_MIRROR, 1, 1}
 };
 
 /* Parse WIDTHxHEIGHT where separator can be x or X. */
@@ -199,25 +201,37 @@ static int parse_sdl_renderer(const char *text, char *out_renderer, size_t out_s
 }
 
 static int parse_mirror_axis(const char *text, int *mirror_x, int *mirror_y) {
-    if (text == NULL || mirror_x == NULL || mirror_y == NULL)
+    char token_buf[64];
+    char *cursor = NULL;
+    char *token = NULL;
+    int seen = 0;
+
+    if (text == NULL || mirror_x == NULL || mirror_y == NULL || text[0] == '\0')
         return 0;
-    if (strcmp(text, "x") == 0) {
-        *mirror_x = 1;
-        return 1;
+    strncpy(token_buf, text, sizeof(token_buf) - 1);
+    token_buf[sizeof(token_buf) - 1] = '\0';
+
+    cursor = token_buf;
+    token = strtok(cursor, ", \t");
+    while (token != NULL) {
+        if (strcmp(token, "x") == 0) {
+            *mirror_x = 1;
+            seen = 1;
+        } else if (strcmp(token, "-x") == 0) {
+            *mirror_x = 0;
+            seen = 1;
+        } else if (strcmp(token, "y") == 0) {
+            *mirror_y = 1;
+            seen = 1;
+        } else if (strcmp(token, "-y") == 0) {
+            *mirror_y = 0;
+            seen = 1;
+        } else {
+            return 0;
+        }
+        token = strtok(NULL, ", \t");
     }
-    if (strcmp(text, "-x") == 0) {
-        *mirror_x = 0;
-        return 1;
-    }
-    if (strcmp(text, "y") == 0) {
-        *mirror_y = 1;
-        return 1;
-    }
-    if (strcmp(text, "-y") == 0) {
-        *mirror_y = 0;
-        return 1;
-    }
-    return 0;
+    return seen;
 }
 
 static void set_error(char *err, size_t err_size, const char *msg) {
@@ -263,8 +277,11 @@ static int parse_int_value(const char *value, int *out_value) {
     long parsed = 0;
     if (value == NULL || out_value == NULL || value[0] == '\0')
         return 0;
+    errno = 0;
     parsed = strtol(value, &end, 10);
     if (end == value || *end != '\0')
+        return 0;
+    if (errno == ERANGE || parsed > INT_MAX || parsed < INT_MIN)
         return 0;
     *out_value = (int)parsed;
     return 1;
@@ -517,7 +534,7 @@ static int set_config_value(hasciicam_config *cfg,
     }
     if (strcmp(key, "mirror") == 0) {
         if (!parse_mirror_axis(value, &cfg->mirror_x, &cfg->mirror_y)) {
-            set_error(err, err_size, "invalid value for mirror: expected x, -x, y, or -y");
+            set_error(err, err_size, "invalid value for mirror: expected x/-x/y/-y tokens");
             return 0;
         }
         return 1;
@@ -663,11 +680,15 @@ static int config_value_as_string(const hasciicam_config *cfg,
         return 1;
     }
     if (strcmp(key, "sdl_vsync") == 0) {
-        const char *vsync = "auto";
+        const char *vsync = NULL;
         if (cfg->sdl_vsync == 1)
             vsync = "on";
         else if (cfg->sdl_vsync == 0)
             vsync = "off";
+        else if (cfg->sdl_vsync == -1)
+            vsync = "auto";
+        else
+            return 0;
         snprintf(out, out_size, "%s", vsync);
         *out_is_quoted = 1;
         return 1;
@@ -678,14 +699,9 @@ static int config_value_as_string(const hasciicam_config *cfg,
         return 1;
     }
     if (strcmp(key, "mirror") == 0) {
-        const char *mirror = "x";
-        if (cfg->mirror_x == 0)
-            mirror = "-x";
-        else if (cfg->mirror_y == 1)
-            mirror = "y";
-        else if (cfg->mirror_y == 0 && cfg->mirror_x != 1)
-            mirror = "-y";
-        snprintf(out, out_size, "%s", mirror);
+        snprintf(out, out_size, "%s,%s",
+                 cfg->mirror_x ? "x" : "-x",
+                 cfg->mirror_y ? "y" : "-y");
         *out_is_quoted = 1;
         return 1;
     }
@@ -768,6 +784,8 @@ int hasciicam_config_load_env(hasciicam_config *cfg, char *err, size_t err_size)
         return 0;
     }
     for (i = 0; i < sizeof(config_keys) / sizeof(config_keys[0]); ++i) {
+        if (!config_keys[i].allow_env_toml)
+            continue;
         const char *value = getenv(config_keys[i].key);
         if (value == NULL || value[0] == '\0')
             continue;
@@ -810,10 +828,17 @@ int hasciicam_config_load_toml(hasciicam_config *cfg,
         size_t k = 0;
         for (k = 0; k < sizeof(config_keys) / sizeof(config_keys[0]); ++k) {
             if (strcmp(config_keys[k].key, key) == 0) {
+                if (!config_keys[k].allow_env_toml) {
+                    set_errorf(err, err_size, "key not allowed in env/toml: %s", key);
+                    ok = 0;
+                    break;
+                }
                 has_known_key = 1;
                 break;
             }
         }
+        if (!ok)
+            break;
         if (!has_known_key) {
             set_errorf(err, err_size, "unknown config key %s", key);
             ok = 0;

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -1,14 +1,18 @@
 #include "app_config.h"
 
-#include <getopt.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 
+#include "tomlc17/tomlc17.h"
+
 #if defined(_WIN32)
+#include "../compat/getopt.h"
 #define strcasecmp _stricmp
 #else
+#include <getopt.h>
 #include <unistd.h>
 #endif
 
@@ -16,6 +20,25 @@
 #define LIVE 0
 #define HTML 1
 #define TEXT 2
+
+typedef enum config_value_kind {
+    CONFIG_VALUE_BOOL = 0,
+    CONFIG_VALUE_INT,
+    CONFIG_VALUE_STRING,
+    CONFIG_VALUE_MODE,
+    CONFIG_VALUE_SIZE,
+    CONFIG_VALUE_PIXEL_SIZE,
+    CONFIG_VALUE_CHAR_SIZE,
+    CONFIG_VALUE_SDL_VSYNC,
+    CONFIG_VALUE_SDL_RENDERER,
+    CONFIG_VALUE_MIRROR
+} config_value_kind;
+
+typedef struct config_key_desc {
+    const char *key;
+    config_value_kind kind;
+    int persist;
+} config_key_desc;
 
 static const struct option long_options[] = {
     {"frames", required_argument, NULL, 1000},
@@ -85,6 +108,38 @@ static const char *help_text =
     " -I --invert       invert colors             - default off\n"
     " -B --background   background color (hex)    - default 000000\n"
     " -F --foreground   foreground color (hex)    - default 00FF00\n";
+
+static const config_key_desc config_keys[] = {
+    {"show_help", CONFIG_VALUE_BOOL, 0},
+    {"show_aahelp", CONFIG_VALUE_BOOL, 0},
+    {"show_version", CONFIG_VALUE_BOOL, 0},
+    {"quiet", CONFIG_VALUE_BOOL, 1},
+    {"mode", CONFIG_VALUE_MODE, 1},
+    {"device", CONFIG_VALUE_STRING, 1},
+    {"input", CONFIG_VALUE_INT, 1},
+    {"size", CONFIG_VALUE_SIZE, 0},
+    {"pixel_size", CONFIG_VALUE_PIXEL_SIZE, 1},
+    {"char_size", CONFIG_VALUE_CHAR_SIZE, 1},
+    {"output_file", CONFIG_VALUE_STRING, 1},
+    {"aa_driver", CONFIG_VALUE_STRING, 1},
+    {"daemon", CONFIG_VALUE_BOOL, 1},
+    {"font_size", CONFIG_VALUE_INT, 1},
+    {"font_face", CONFIG_VALUE_STRING, 1},
+    {"refresh", CONFIG_VALUE_INT, 1},
+    {"aa_bright", CONFIG_VALUE_INT, 1},
+    {"aa_contrast", CONFIG_VALUE_INT, 1},
+    {"aa_gamma", CONFIG_VALUE_INT, 1},
+    {"invert", CONFIG_VALUE_BOOL, 1},
+    {"background", CONFIG_VALUE_STRING, 1},
+    {"foreground", CONFIG_VALUE_STRING, 1},
+    {"uid", CONFIG_VALUE_INT, 1},
+    {"gid", CONFIG_VALUE_INT, 1},
+    {"frames", CONFIG_VALUE_INT, 1},
+    {"sdl_renderer", CONFIG_VALUE_SDL_RENDERER, 1},
+    {"sdl_vsync", CONFIG_VALUE_SDL_VSYNC, 1},
+    {"fullscreen", CONFIG_VALUE_BOOL, 1},
+    {"mirror", CONFIG_VALUE_MIRROR, 1}
+};
 
 /* Parse WIDTHxHEIGHT where separator can be x or X. */
 static int parse_wxh(const char *text, int *out_w, int *out_h) {
@@ -165,6 +220,503 @@ static int parse_mirror_axis(const char *text, int *mirror_x, int *mirror_y) {
     return 0;
 }
 
+static void set_error(char *err, size_t err_size, const char *msg) {
+    if (err == NULL || err_size == 0)
+        return;
+    if (msg == NULL)
+        msg = "invalid configuration";
+    strncpy(err, msg, err_size - 1);
+    err[err_size - 1] = '\0';
+}
+
+static void set_errorf(char *err, size_t err_size, const char *fmt, const char *key) {
+    if (err == NULL || err_size == 0)
+        return;
+    if (fmt == NULL)
+        fmt = "invalid value";
+#if defined(_WIN32)
+    _snprintf(err, err_size - 1, fmt, key);
+    err[err_size - 1] = '\0';
+#else
+    snprintf(err, err_size, fmt, key);
+#endif
+}
+
+static int parse_bool_value(const char *value, int *out_value) {
+    if (value == NULL || out_value == NULL)
+        return 0;
+    if (strcmp(value, "1") == 0 || strcasecmp(value, "true") == 0 ||
+        strcasecmp(value, "yes") == 0 || strcasecmp(value, "on") == 0) {
+        *out_value = 1;
+        return 1;
+    }
+    if (strcmp(value, "0") == 0 || strcasecmp(value, "false") == 0 ||
+        strcasecmp(value, "no") == 0 || strcasecmp(value, "off") == 0) {
+        *out_value = 0;
+        return 1;
+    }
+    return 0;
+}
+
+static int parse_int_value(const char *value, int *out_value) {
+    char *end = NULL;
+    long parsed = 0;
+    if (value == NULL || out_value == NULL || value[0] == '\0')
+        return 0;
+    parsed = strtol(value, &end, 10);
+    if (end == value || *end != '\0')
+        return 0;
+    *out_value = (int)parsed;
+    return 1;
+}
+
+static void apply_mode_side_effects(hasciicam_config *cfg) {
+    if (cfg == NULL)
+        return;
+    if (!cfg->explicit_output) {
+        if (cfg->mode == HTML) {
+            strcpy(cfg->aafile, "hasciicam.html");
+        } else if (cfg->mode == TEXT) {
+            strcpy(cfg->aafile, "hasciicam.asc");
+        }
+    }
+}
+
+static int set_config_value(hasciicam_config *cfg,
+                            const char *key,
+                            const char *value,
+                            char *err,
+                            size_t err_size) {
+    int iv = 0;
+    int w = 0;
+    int h = 0;
+
+    if (cfg == NULL || key == NULL || value == NULL) {
+        set_error(err, err_size, "invalid configuration input");
+        return 0;
+    }
+
+    if (strcmp(key, "show_help") == 0) {
+        if (!parse_bool_value(value, &cfg->show_help)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "show_aahelp") == 0) {
+        if (!parse_bool_value(value, &cfg->show_aahelp)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "show_version") == 0) {
+        if (!parse_bool_value(value, &cfg->show_version)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "quiet") == 0) {
+        if (!parse_bool_value(value, &cfg->quiet)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "mode") == 0) {
+        if (strcasecmp(value, "live") == 0) {
+            cfg->mode = LIVE;
+        } else if (strcasecmp(value, "html") == 0) {
+            cfg->mode = HTML;
+        } else if (strcasecmp(value, "text") == 0) {
+            cfg->mode = TEXT;
+        } else {
+            set_error(err, err_size, "invalid value for mode: expected live, html, or text");
+            return 0;
+        }
+        apply_mode_side_effects(cfg);
+        return 1;
+    }
+    if (strcmp(key, "device") == 0) {
+        strncpy(cfg->device, value, sizeof(cfg->device) - 1);
+        cfg->device[sizeof(cfg->device) - 1] = '\0';
+        return 1;
+    }
+    if (strcmp(key, "input") == 0) {
+        if (!parse_int_value(value, &iv)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        if (iv > 3) {
+            set_error(err, err_size, "invalid value for input: expected 0..3");
+            return 0;
+        }
+        cfg->input_channel = iv;
+        return 1;
+    }
+    if (strcmp(key, "size") == 0) {
+        if (!parse_wxh(value, &w, &h)) {
+            set_error(err, err_size, "invalid value for size: expected WxH");
+            return 0;
+        }
+        cfg->size_w = w;
+        cfg->size_h = h;
+        cfg->size_intent = (cfg->mode == HTML) ? HASCIICAM_SIZE_CHARS : HASCIICAM_SIZE_PIXELS;
+        cfg->explicit_size = 1;
+        return 1;
+    }
+    if (strcmp(key, "pixel_size") == 0) {
+        if (!parse_wxh(value, &w, &h)) {
+            set_error(err, err_size, "invalid value for pixel_size: expected WxH");
+            return 0;
+        }
+        cfg->size_w = w;
+        cfg->size_h = h;
+        cfg->size_intent = HASCIICAM_SIZE_PIXELS;
+        cfg->explicit_size = 1;
+        return 1;
+    }
+    if (strcmp(key, "char_size") == 0) {
+        if (!parse_wxh(value, &w, &h)) {
+            set_error(err, err_size, "invalid value for char_size: expected WxH");
+            return 0;
+        }
+        cfg->size_w = w;
+        cfg->size_h = h;
+        cfg->size_intent = HASCIICAM_SIZE_CHARS;
+        cfg->explicit_size = 1;
+        return 1;
+    }
+    if (strcmp(key, "output_file") == 0) {
+        strncpy(cfg->aafile, value, sizeof(cfg->aafile) - 1);
+        cfg->aafile[sizeof(cfg->aafile) - 1] = '\0';
+        cfg->explicit_output = 1;
+        return 1;
+    }
+    if (strcmp(key, "aa_driver") == 0) {
+        strncpy(cfg->aadriver, value, sizeof(cfg->aadriver) - 1);
+        cfg->aadriver[sizeof(cfg->aadriver) - 1] = '\0';
+        cfg->explicit_aadriver = 1;
+        return 1;
+    }
+    if (strcmp(key, "daemon") == 0) {
+        if (!parse_bool_value(value, &cfg->daemon_mode)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "font_size") == 0) {
+        if (!parse_int_value(value, &iv)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        cfg->fontsize = iv;
+        switch (cfg->fontsize) {
+        case 1: cfg->linespace = 5; break;
+        case 2: cfg->linespace = 10; break;
+        case 3: cfg->linespace = 11; break;
+        case 4: cfg->linespace = 13; break;
+        default: cfg->linespace = 15; break;
+        }
+        return 1;
+    }
+    if (strcmp(key, "font_face") == 0) {
+        strncpy(cfg->fontface, value, sizeof(cfg->fontface) - 1);
+        cfg->fontface[sizeof(cfg->fontface) - 1] = '\0';
+        return 1;
+    }
+    if (strcmp(key, "refresh") == 0) {
+        if (!parse_int_value(value, &cfg->refresh)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "aa_bright") == 0) {
+        if (!parse_int_value(value, &cfg->aa_bright)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "aa_contrast") == 0) {
+        if (!parse_int_value(value, &cfg->aa_contrast)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "aa_gamma") == 0) {
+        if (!parse_int_value(value, &cfg->aa_gamma)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "invert") == 0) {
+        if (!parse_bool_value(value, &cfg->invert)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "background") == 0) {
+        strncpy(cfg->background, value, sizeof(cfg->background) - 1);
+        cfg->background[sizeof(cfg->background) - 1] = '\0';
+        return 1;
+    }
+    if (strcmp(key, "foreground") == 0) {
+        strncpy(cfg->foreground, value, sizeof(cfg->foreground) - 1);
+        cfg->foreground[sizeof(cfg->foreground) - 1] = '\0';
+        return 1;
+    }
+    if (strcmp(key, "uid") == 0) {
+        if (!parse_int_value(value, &cfg->uid)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "gid") == 0) {
+        if (!parse_int_value(value, &cfg->gid)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "frames") == 0) {
+        if (!parse_int_value(value, &iv)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        cfg->max_frames = (iv < 0) ? 0 : iv;
+        return 1;
+    }
+    if (strcmp(key, "sdl_renderer") == 0) {
+        if (!parse_sdl_renderer(value, cfg->sdl_renderer, sizeof(cfg->sdl_renderer))) {
+            set_error(err, err_size, "invalid value for sdl_renderer: expected accelerated, software, or auto");
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "sdl_vsync") == 0) {
+        if (!parse_sdl_vsync(value, &cfg->sdl_vsync)) {
+            set_error(err, err_size, "invalid value for sdl_vsync: expected on, off, or auto");
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "fullscreen") == 0) {
+        if (!parse_bool_value(value, &cfg->sdl_fullscreen)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
+    if (strcmp(key, "mirror") == 0) {
+        if (!parse_mirror_axis(value, &cfg->mirror_x, &cfg->mirror_y)) {
+            set_error(err, err_size, "invalid value for mirror: expected x, -x, y, or -y");
+            return 0;
+        }
+        return 1;
+    }
+
+    set_errorf(err, err_size, "unknown config key %s", key);
+    return 0;
+}
+
+static int config_key_is_persisted(const char *key) {
+    size_t i = 0;
+    for (i = 0; i < sizeof(config_keys) / sizeof(config_keys[0]); ++i) {
+        if (strcmp(config_keys[i].key, key) == 0)
+            return config_keys[i].persist;
+    }
+    return 0;
+}
+
+static int config_value_as_string(const hasciicam_config *cfg,
+                                  const char *key,
+                                  char *out,
+                                  size_t out_size,
+                                  int *out_is_quoted) {
+    if (cfg == NULL || key == NULL || out == NULL || out_size == 0 || out_is_quoted == NULL)
+        return 0;
+
+    if (strcmp(key, "quiet") == 0) {
+        snprintf(out, out_size, "%s", cfg->quiet ? "true" : "false");
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "mode") == 0) {
+        const char *mode = "live";
+        if (cfg->mode == HTML)
+            mode = "html";
+        else if (cfg->mode == TEXT)
+            mode = "text";
+        snprintf(out, out_size, "%s", mode);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "device") == 0) {
+        snprintf(out, out_size, "%s", cfg->device);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "input") == 0) {
+        snprintf(out, out_size, "%d", cfg->input_channel);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "pixel_size") == 0 || strcmp(key, "char_size") == 0) {
+        if (!cfg->explicit_size)
+            return 0;
+        if ((strcmp(key, "pixel_size") == 0 && cfg->size_intent != HASCIICAM_SIZE_PIXELS) ||
+            (strcmp(key, "char_size") == 0 && cfg->size_intent != HASCIICAM_SIZE_CHARS)) {
+            return 0;
+        }
+        snprintf(out, out_size, "%dx%d", cfg->size_w, cfg->size_h);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "output_file") == 0) {
+        snprintf(out, out_size, "%s", cfg->aafile);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "aa_driver") == 0) {
+        snprintf(out, out_size, "%s", cfg->aadriver);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "daemon") == 0) {
+        snprintf(out, out_size, "%s", cfg->daemon_mode ? "true" : "false");
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "font_size") == 0) {
+        snprintf(out, out_size, "%d", cfg->fontsize);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "font_face") == 0) {
+        snprintf(out, out_size, "%s", cfg->fontface);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "refresh") == 0) {
+        snprintf(out, out_size, "%d", cfg->refresh);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "aa_bright") == 0) {
+        snprintf(out, out_size, "%d", cfg->aa_bright);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "aa_contrast") == 0) {
+        snprintf(out, out_size, "%d", cfg->aa_contrast);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "aa_gamma") == 0) {
+        snprintf(out, out_size, "%d", cfg->aa_gamma);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "invert") == 0) {
+        snprintf(out, out_size, "%s", cfg->invert ? "true" : "false");
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "background") == 0) {
+        snprintf(out, out_size, "%s", cfg->background);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "foreground") == 0) {
+        snprintf(out, out_size, "%s", cfg->foreground);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "uid") == 0) {
+        snprintf(out, out_size, "%d", cfg->uid);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "gid") == 0) {
+        snprintf(out, out_size, "%d", cfg->gid);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "frames") == 0) {
+        snprintf(out, out_size, "%d", cfg->max_frames);
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "sdl_renderer") == 0) {
+        if (cfg->sdl_renderer[0] == '\0')
+            return 0;
+        snprintf(out, out_size, "%s", cfg->sdl_renderer);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "sdl_vsync") == 0) {
+        const char *vsync = "auto";
+        if (cfg->sdl_vsync == 1)
+            vsync = "on";
+        else if (cfg->sdl_vsync == 0)
+            vsync = "off";
+        snprintf(out, out_size, "%s", vsync);
+        *out_is_quoted = 1;
+        return 1;
+    }
+    if (strcmp(key, "fullscreen") == 0) {
+        snprintf(out, out_size, "%s", cfg->sdl_fullscreen ? "true" : "false");
+        *out_is_quoted = 0;
+        return 1;
+    }
+    if (strcmp(key, "mirror") == 0) {
+        const char *mirror = "x";
+        if (cfg->mirror_x == 0)
+            mirror = "-x";
+        else if (cfg->mirror_y == 1)
+            mirror = "y";
+        else if (cfg->mirror_y == 0 && cfg->mirror_x != 1)
+            mirror = "-y";
+        snprintf(out, out_size, "%s", mirror);
+        *out_is_quoted = 1;
+        return 1;
+    }
+
+    return 0;
+}
+
+static void toml_escape_and_write(FILE *fp, const char *value) {
+    const unsigned char *p = (const unsigned char *)value;
+    fputc('"', fp);
+    while (*p != '\0') {
+        unsigned char ch = *p++;
+        if (ch == '\\') {
+            fputs("\\\\", fp);
+        } else if (ch == '"') {
+            fputs("\\\"", fp);
+        } else if (ch == '\n') {
+            fputs("\\n", fp);
+        } else if (ch == '\t') {
+            fputs("\\t", fp);
+        } else if (ch == '\r') {
+            fputs("\\r", fp);
+        } else if (ch < 0x20) {
+            fprintf(fp, "\\u%04x", (unsigned int)ch);
+        } else {
+            fputc((int)ch, fp);
+        }
+    }
+    fputc('"', fp);
+}
+
 void hasciicam_config_init_defaults(hasciicam_config *cfg) {
     if (cfg == NULL)
         return;
@@ -202,10 +754,135 @@ void hasciicam_config_init_defaults(hasciicam_config *cfg) {
     cfg->max_frames = 0;
     cfg->explicit_size = 0;
     cfg->explicit_aadriver = 0;
+    cfg->explicit_output = 0;
     cfg->sdl_vsync = -2;
     cfg->sdl_fullscreen = 0;
     cfg->mirror_x = 1;
     cfg->mirror_y = 0;
+}
+
+int hasciicam_config_load_env(hasciicam_config *cfg, char *err, size_t err_size) {
+    size_t i = 0;
+    if (cfg == NULL) {
+        set_error(err, err_size, "null config");
+        return 0;
+    }
+    for (i = 0; i < sizeof(config_keys) / sizeof(config_keys[0]); ++i) {
+        const char *value = getenv(config_keys[i].key);
+        if (value == NULL || value[0] == '\0')
+            continue;
+        if (!set_config_value(cfg, config_keys[i].key, value, err, err_size))
+            return 0;
+    }
+    return 1;
+}
+
+int hasciicam_config_load_toml(hasciicam_config *cfg,
+                               const char *path,
+                               char *err,
+                               size_t err_size) {
+    toml_result_t result;
+    int ok = 1;
+    int i = 0;
+    char value_buf[128];
+    if (cfg == NULL || path == NULL) {
+        set_error(err, err_size, "null config or path");
+        return 0;
+    }
+
+    result = toml_parse_file_ex(path);
+    if (!result.ok) {
+        set_error(err, err_size, result.errmsg);
+        toml_free(result);
+        return 0;
+    }
+
+    if (result.toptab.type != TOML_TABLE) {
+        set_error(err, err_size, "toml root must be a table");
+        toml_free(result);
+        return 0;
+    }
+
+    for (i = 0; i < result.toptab.u.tab.size; ++i) {
+        const char *key = result.toptab.u.tab.key[i];
+        toml_datum_t value = result.toptab.u.tab.value[i];
+        int has_known_key = 0;
+        size_t k = 0;
+        for (k = 0; k < sizeof(config_keys) / sizeof(config_keys[0]); ++k) {
+            if (strcmp(config_keys[k].key, key) == 0) {
+                has_known_key = 1;
+                break;
+            }
+        }
+        if (!has_known_key) {
+            set_errorf(err, err_size, "unknown config key %s", key);
+            ok = 0;
+            break;
+        }
+
+        if (value.type == TOML_STRING) {
+            if (!set_config_value(cfg, key, value.u.s, err, err_size)) {
+                ok = 0;
+                break;
+            }
+        } else if (value.type == TOML_INT64) {
+            snprintf(value_buf, sizeof(value_buf), "%lld", (long long)value.u.int64);
+            if (!set_config_value(cfg, key, value_buf, err, err_size)) {
+                ok = 0;
+                break;
+            }
+        } else if (value.type == TOML_BOOLEAN) {
+            if (!set_config_value(cfg, key, value.u.boolean ? "true" : "false", err, err_size)) {
+                ok = 0;
+                break;
+            }
+        } else {
+            set_errorf(err, err_size, "unsupported TOML type for key %s", key);
+            ok = 0;
+            break;
+        }
+    }
+
+    toml_free(result);
+    return ok;
+}
+
+int hasciicam_config_save_toml(const hasciicam_config *cfg,
+                               const char *path,
+                               char *err,
+                               size_t err_size) {
+    FILE *fp = NULL;
+    size_t i = 0;
+    if (cfg == NULL || path == NULL) {
+        set_error(err, err_size, "null config or path");
+        return 0;
+    }
+    fp = fopen(path, "wb");
+    if (fp == NULL) {
+        set_error(err, err_size, "cannot open file for writing");
+        return 0;
+    }
+
+    for (i = 0; i < sizeof(config_keys) / sizeof(config_keys[0]); ++i) {
+        char value[256];
+        int quoted = 0;
+        if (!config_key_is_persisted(config_keys[i].key))
+            continue;
+        if (!config_value_as_string(cfg, config_keys[i].key, value, sizeof(value), &quoted))
+            continue;
+        fprintf(fp, "%s = ", config_keys[i].key);
+        if (quoted)
+            toml_escape_and_write(fp, value);
+        else
+            fputs(value, fp);
+        fputc('\n', fp);
+    }
+
+    if (fclose(fp) != 0) {
+        set_error(err, err_size, "failed to close config file");
+        return 0;
+    }
+    return 1;
 }
 
 void hasciicam_config_parse(hasciicam_config *cfg,
@@ -218,59 +895,52 @@ void hasciicam_config_parse(hasciicam_config *cfg,
     int short_size_w = 0;
     int short_size_h = 0;
     int short_size_set = 0;
+    char env_err[200];
 
     if (cfg == NULL)
         return;
+
+    if (!hasciicam_config_load_env(cfg, env_err, sizeof(env_err))) {
+        fprintf(stderr, "!! %s\n", env_err);
+        exit(1);
+    }
 
     do {
         res = getopt_long(argc, argv, short_options, long_options, NULL);
         switch (res) {
         case 1000:
-            cfg->max_frames = atoi(optarg);
-            if (cfg->max_frames < 0)
-                cfg->max_frames = 0;
+            if (!set_config_value(cfg, "frames", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'h':
-            fprintf(stderr, "%s", help_text);
-            exit(0);
+            cfg->show_help = 1;
             break;
         case 'H':
-            fprintf(stderr, "%s", help_text);
-            fprintf(stderr, "\naalib options:\n%s", aa_help_text);
-            exit(0);
+            cfg->show_aahelp = 1;
             break;
         case 'v':
-            fprintf(stderr,
-                    "\n%s %s - (h)ascii 4 the masses! - https://ascii.dyne.org\n"
-                    "(c)2000-2025 RASTASOFT by Jaromil @ Dyne.org\n\n",
-                    package, version);
-            exit(0);
+            cfg->show_version = 1;
             break;
         case 'q':
             cfg->quiet = 1;
             break;
         case 'm':
-            if (strcasecmp(optarg, "live") == 0) {
-                cfg->mode = LIVE;
-            } else if (strcasecmp(optarg, "html") == 0) {
-                cfg->mode = HTML;
-                strcpy(cfg->aafile, "hasciicam.html");
-            } else if (strcasecmp(optarg, "text") == 0) {
-                cfg->mode = TEXT;
-                strcpy(cfg->aafile, "hasciicam.asc");
-            } else {
-                fprintf(stderr, "!! invalid mode selected, using live\n");
-                cfg->mode = LIVE;
+            if (!set_config_value(cfg, "mode", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
             }
             break;
         case 'd':
-            strncpy(cfg->device, optarg, sizeof(cfg->device) - 1);
-            cfg->device[sizeof(cfg->device) - 1] = '\0';
+            if (!set_config_value(cfg, "device", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'i':
-            cfg->input_channel = atoi(optarg);
-            if (cfg->input_channel > 3) {
-                fprintf(stderr, "invalid input selected\n");
+            if (!set_config_value(cfg, "input", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
             break;
@@ -283,30 +953,26 @@ void hasciicam_config_parse(hasciicam_config *cfg,
             cfg->explicit_size = 1;
             break;
         case 1001:
-            if (!parse_wxh(optarg, &cfg->size_w, &cfg->size_h)) {
-                fprintf(stderr, "!! invalid pixel size '%s', expected WxH\n", optarg);
+            if (!set_config_value(cfg, "pixel_size", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
-            cfg->size_intent = HASCIICAM_SIZE_PIXELS;
-            cfg->explicit_size = 1;
             break;
         case 1002:
-            if (!parse_wxh(optarg, &cfg->size_w, &cfg->size_h)) {
-                fprintf(stderr, "!! invalid char size '%s', expected WxH\n", optarg);
+            if (!set_config_value(cfg, "char_size", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
-            cfg->size_intent = HASCIICAM_SIZE_CHARS;
-            cfg->explicit_size = 1;
             break;
         case 1003:
-            if (!parse_sdl_renderer(optarg, cfg->sdl_renderer, sizeof(cfg->sdl_renderer))) {
-                fprintf(stderr, "!! invalid SDL renderer '%s', expected accelerated, software, or auto\n", optarg);
+            if (!set_config_value(cfg, "sdl_renderer", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
             break;
         case 1004:
-            if (!parse_sdl_vsync(optarg, &cfg->sdl_vsync)) {
-                fprintf(stderr, "!! invalid SDL vsync '%s', expected on, off, or auto\n", optarg);
+            if (!set_config_value(cfg, "sdl_vsync", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
             break;
@@ -314,67 +980,90 @@ void hasciicam_config_parse(hasciicam_config *cfg,
             cfg->sdl_fullscreen = 1;
             break;
         case 1006:
-            if (!parse_mirror_axis(optarg, &cfg->mirror_x, &cfg->mirror_y)) {
-                fprintf(stderr, "!! invalid mirror axis '%s', expected x, -x, y, or -y\n", optarg);
+            if (!set_config_value(cfg, "mirror", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
             break;
         case 'S':
-            cfg->fontsize = atoi(optarg);
-            switch (cfg->fontsize) {
-            case 1: cfg->linespace = 5; break;
-            case 2: cfg->linespace = 10; break;
-            case 3: cfg->linespace = 11; break;
-            case 4: cfg->linespace = 13; break;
-            default: cfg->linespace = 15; break;
+            if (!set_config_value(cfg, "font_size", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
             }
             break;
         case 'a':
-            strncpy(cfg->fontface, optarg, sizeof(cfg->fontface) - 1);
-            cfg->fontface[sizeof(cfg->fontface) - 1] = '\0';
+            if (!set_config_value(cfg, "font_face", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'r':
-            cfg->refresh = atoi(optarg);
+            if (!set_config_value(cfg, "refresh", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'o':
             if (cfg->mode > 0) {
-                strncpy(cfg->aafile, optarg, sizeof(cfg->aafile) - 1);
-                cfg->aafile[sizeof(cfg->aafile) - 1] = '\0';
+                if (!set_config_value(cfg, "output_file", optarg, env_err, sizeof(env_err))) {
+                    fprintf(stderr, "!! %s\n", env_err);
+                    exit(1);
+                }
             }
             break;
         case 'O':
-            strncpy(cfg->aadriver, optarg, sizeof(cfg->aadriver) - 1);
-            cfg->aadriver[sizeof(cfg->aadriver) - 1] = '\0';
-            cfg->explicit_aadriver = 1;
+            if (!set_config_value(cfg, "aa_driver", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'D':
             cfg->daemon_mode = 1;
             break;
         case 'b':
-            cfg->aa_bright = atoi(optarg);
+            if (!set_config_value(cfg, "aa_bright", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'c':
-            cfg->aa_contrast = atoi(optarg);
+            if (!set_config_value(cfg, "aa_contrast", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'g':
-            cfg->aa_gamma = atoi(optarg);
+            if (!set_config_value(cfg, "aa_gamma", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'I':
             cfg->invert = 1;
             break;
         case 'B':
-            strncpy(cfg->background, optarg, sizeof(cfg->background) - 1);
-            cfg->background[sizeof(cfg->background) - 1] = '\0';
+            if (!set_config_value(cfg, "background", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'F':
-            strncpy(cfg->foreground, optarg, sizeof(cfg->foreground) - 1);
-            cfg->foreground[sizeof(cfg->foreground) - 1] = '\0';
+            if (!set_config_value(cfg, "foreground", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'U':
-            cfg->uid = atoi(optarg);
+            if (!set_config_value(cfg, "uid", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'G':
-            cfg->gid = atoi(optarg);
+            if (!set_config_value(cfg, "gid", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         default:
             break;
@@ -388,6 +1077,23 @@ void hasciicam_config_parse(hasciicam_config *cfg,
             cfg->size_intent = HASCIICAM_SIZE_CHARS;
         else
             cfg->size_intent = HASCIICAM_SIZE_PIXELS;
+    }
+
+    if (cfg->show_help) {
+        fprintf(stderr, "%s", help_text);
+        exit(0);
+    }
+    if (cfg->show_aahelp) {
+        fprintf(stderr, "%s", help_text);
+        fprintf(stderr, "\naalib options:\n%s", aa_help_text);
+        exit(0);
+    }
+    if (cfg->show_version) {
+        fprintf(stderr,
+                "\n%s %s - (h)ascii 4 the masses! - https://ascii.dyne.org\n"
+                "(c)2000-2025 RASTASOFT by Jaromil @ Dyne.org\n\n",
+                package, version);
+        exit(0);
     }
 
     if (cfg->mode == HTML && cfg->size_intent == HASCIICAM_SIZE_PIXELS) {

--- a/src/app/app_config.h
+++ b/src/app/app_config.h
@@ -1,6 +1,8 @@
 #ifndef HASCIICAM_APP_CONFIG_H
 #define HASCIICAM_APP_CONFIG_H
 
+#include <stddef.h>
+
 typedef enum hasciicam_size_intent {
     HASCIICAM_SIZE_NONE = 0,
     HASCIICAM_SIZE_PIXELS,
@@ -24,11 +26,15 @@ typedef struct hasciicam_config {
     hasciicam_size_intent size_intent;
     int explicit_size;
     int explicit_aadriver;
+    int explicit_output;
     int sdl_vsync;
     int sdl_fullscreen;
     int mirror_x;
     int mirror_y;
     int max_frames;
+    int show_help;
+    int show_aahelp;
+    int show_version;
     int uid;
     int gid;
     char device[256];
@@ -47,5 +53,14 @@ void hasciicam_config_parse(hasciicam_config *cfg,
                             const char *aa_help_text,
                             const char *package,
                             const char *version);
+int hasciicam_config_load_env(hasciicam_config *cfg, char *err, size_t err_size);
+int hasciicam_config_load_toml(hasciicam_config *cfg,
+                               const char *path,
+                               char *err,
+                               size_t err_size);
+int hasciicam_config_save_toml(const hasciicam_config *cfg,
+                               const char *path,
+                               char *err,
+                               size_t err_size);
 
 #endif

--- a/src/app/tomlc17/LICENSE
+++ b/src/app/tomlc17/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024-2026, CK Tan
+https://github.com/cktan/tomlc17
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/app/tomlc17/README
+++ b/src/app/tomlc17/README
@@ -1,0 +1,4 @@
+Vendored third-party dependency: cktan/tomlc17
+Upstream: https://github.com/cktan/tomlc17
+Source commit: main branch snapshot downloaded on 2026-05-31
+Files used: src/tomlc17.h, src/tomlc17.c, LICENSE

--- a/src/app/tomlc17/tomlc17.c
+++ b/src/app/tomlc17/tomlc17.c
@@ -1,0 +1,2977 @@
+/* Copyright (c) 2024-2026, CK Tan.
+ * https://github.com/cktan/tomlc17/blob/main/LICENSE
+ */
+#include "tomlc17.h"
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const toml_datum_t DATUM_ZERO = {0};
+
+static toml_option_t toml_option = {0, realloc, free};
+
+#define MALLOC(n) toml_option.mem_realloc(0, n)
+#define REALLOC(p, n) toml_option.mem_realloc(p, n)
+#define FREE(p) toml_option.mem_free(p)
+
+#define DO(x)                                                                  \
+  if (x)                                                                       \
+    return -1;                                                                 \
+  else                                                                         \
+    (void)0
+
+// Copy string src to dst where dst is limited to dstsz that includes
+// NUL. Return 0 on success, -1 otherwise (because src[] is longer than dst[]).
+static inline int copystring(char *dst, int dstsz, const char *src) {
+  int srcsz = strlen(src) + 1;
+  if (srcsz > dstsz) {
+    return -1;
+  }
+  memcpy(dst, src, srcsz);
+  return 0;
+}
+
+/*
+ *  Error buffer
+ */
+typedef struct ebuf_t ebuf_t;
+struct ebuf_t {
+  char *ptr;
+  int len;
+};
+
+/*
+ *  Format an error into ebuf[]. Always return -1.
+ */
+static int SETERROR(ebuf_t ebuf, int lineno, const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  char *p = ebuf.ptr;
+  char *q = p + ebuf.len;
+  if (lineno) {
+    snprintf(p, p < q ? q - p : 0, "(line %d) ", lineno);
+    p += strlen(p);
+  }
+  vsnprintf(p, p < q ? q - p : 0, fmt, args);
+  va_end(args);
+  return -1;
+}
+
+/*
+ *  Memory pool. Allocated a big block once and hand out piecemeal.
+ */
+typedef struct pool_t pool_t;
+struct pool_t {
+  int max;     // size of buf[]
+  int top;     // offset of first free byte in buf[]
+  char buf[1]; // first byte starts here
+};
+
+/**
+ *  Create a memory pool of N bytes. Return the memory pool on
+ *  success, or NULL if out of memory.
+ */
+static pool_t *pool_create(int N) {
+  if (N <= 0) {
+    N = 100; // minimum
+  }
+  int totalsz = sizeof(pool_t) + N;
+  pool_t *pool = MALLOC(totalsz);
+  if (!pool) {
+    return NULL;
+  }
+  memset(pool, 0, totalsz);
+  pool->max = N;
+  return pool;
+}
+
+/**
+ *  Destroy a memory pool.
+ */
+static void pool_destroy(pool_t *pool) { FREE(pool); }
+
+/**
+ *  Allocate n bytes from pool. Return the memory allocated on
+ *  success, or NULL if out of memory.
+ */
+static char *pool_alloc(pool_t *pool, int n) {
+  if (pool->top + n > pool->max) {
+    return NULL;
+  }
+  char *ret = pool->buf + pool->top;
+  pool->top += n;
+  return ret;
+}
+
+/* This is a string view. */
+typedef struct span_t span_t;
+struct span_t {
+  const char *ptr;
+  int len;
+};
+
+/* Represents a multi-part key */
+#define KEYPARTMAX 10
+typedef struct keypart_t keypart_t;
+struct keypart_t {
+  int nspan;
+  span_t span[KEYPARTMAX];
+};
+
+static int utf8_to_ucs(const char *s, int len, uint32_t *ret);
+static int ucs_to_utf8(uint32_t code, char buf[4]);
+
+// flags for toml_datum_t::flag.
+#define FLAG_INLINED 1
+#define FLAG_STDEXPR 2
+#define FLAG_EXPLICIT 4
+
+// Maximum levels of brackets and braces to prevent
+// stack overflow during recursive descent of the parser.
+#define BRACKET_LEVEL_MAX 30
+#define BRACE_LEVEL_MAX 30
+#define TABLE_MAX (1 << 14) // 16k
+#define ARRAY_MAX (1 << 14) // 16k
+
+static inline size_t align8(size_t x) { return (((x) + 7) & ~7); }
+
+enum toktyp_t {
+  TOK_DOT = 1,
+  TOK_EQUAL,
+  TOK_COMMA,
+  TOK_LBRACK,  // [
+  TOK_LLBRACK, // [[
+  TOK_RBRACK,  // ]
+  TOK_RRBRACK, // ]]
+  TOK_LBRACE,  // {
+  TOK_RBRACE,  // }
+  TOK_LIT,
+  TOK_STRING,      // "string"
+  TOK_MLSTRING,    // """multi-line-string"""
+  TOK_LITSTRING,   // 'lit-string'
+  TOK_MLLITSTRING, // '''multi-line-lit-string'''
+  TOK_TIME,
+  TOK_DATE,
+  TOK_DATETIME,
+  TOK_DATETIMETZ,
+  TOK_INTEGER,
+  TOK_FLOAT,
+  TOK_BOOL,
+  TOK_ENDL,
+  TOK_FIN = -5000, // EOF
+};
+typedef enum toktyp_t toktyp_t;
+typedef struct scanner_t scanner_t;
+
+/* Remember the current state of a scanner */
+typedef struct scanner_state_t scanner_state_t;
+struct scanner_state_t {
+  scanner_t *sp;
+  const char *cur; // points into scanner_t::src[]
+  int lineno;      // current line number
+  const char *line_start;
+};
+
+// A scan token
+typedef struct token_t token_t;
+struct token_t {
+  toktyp_t toktyp;
+  int lineno;
+  int colno;
+  span_t str;
+
+  // values represented by str
+  union {
+    const char *escp; // point to an esc char in str
+    int64_t int64;
+    double fp64;
+    bool b1;
+    struct {
+      // validity depends on toktyp for TIME, DATE, DATETIME, DATETIMETZ
+      int year, month, day, hour, minute, sec, usec;
+      int tz; // +- minutes
+    } tsval;
+  } u;
+};
+
+// Scanner object
+struct scanner_t {
+  const char *src;  // src[] is a NUL-terminated string
+  const char *endp; // end of src[]. always pointing at a NUL char.
+  const char *cur;  // current char in src[]
+  int lineno;       // line number of current char
+  const char *line_start;
+  char *errmsg; // set to ebuf.ptr if there was an error
+  ebuf_t ebuf;  // buffer to store error message
+
+  int bracket_level; // count depth of [ ]
+  int brace_level;   // count depth of { }
+};
+static void scan_init(scanner_t *sp, const char *src, int len, char *errbuf,
+                      int errbufsz);
+static int scan_key(scanner_t *sp, token_t *tok);
+static int scan_value(scanner_t *sp, token_t *tok);
+// restore scanner to state before tok was returned
+static scanner_state_t scan_mark(scanner_t *sp);
+static void scan_restore(scanner_t *sp, scanner_state_t state);
+
+#ifndef min
+static inline int min(int a, int b) { return a < b ? a : b; }
+#endif
+
+// Copy up to dstsz - 1 chars from the current position of the scanner
+// to dst, and always terminate dst[] with a NUL if dstsz > 0.
+static void scan_copystr(scanner_t *sp, char *dst, int dstsz) {
+  assert(dstsz > 0);
+  int len = min(sp->endp - sp->cur, dstsz - 1); // account for NUL
+  if (len > 0) {
+    memcpy(dst, sp->cur, len);
+    dst[len] = '\0';
+  }
+}
+
+// Parser object
+typedef struct parser_t parser_t;
+struct parser_t {
+  scanner_t scanner;
+  toml_datum_t toptab;  // top table
+  toml_datum_t *curtab; // current table
+  pool_t *pool;         // memory pool for strings
+  ebuf_t ebuf;          // buffer to store last error message
+};
+
+// Find key in tab and return its index. If not found, return -1.
+static int tab_find(toml_datum_t *tab, span_t key) {
+  assert(tab->type == TOML_TABLE);
+  for (int i = 0, top = tab->u.tab.size; i < top; i++) {
+    if (tab->u.tab.len[i] == key.len &&
+        0 == memcmp(tab->u.tab.key[i], key.ptr, key.len)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Put key into tab dictionary. Return a pointer to the datum for the key.
+// If the key already exists, returns a pointer to its existing datum (the
+// datum is NOT zeroed — callers must check datum->type to detect duplicates).
+// If the key is new, appends it with a zero datum and returns a pointer to it.
+// Returns NULL on allocation failure.
+//
+// Dual-use: tab_add() uses the non-zero type to detect and reject duplicates;
+// datum_copy/datum_merge() use it to locate or create a slot for writing.
+static toml_datum_t *tab_emplace(toml_datum_t *tab, span_t key,
+                                 const char **reason) {
+  assert(tab->type == TOML_TABLE);
+  int i = tab_find(tab, key);
+  if (i >= 0) {
+    return &tab->u.tab.value[i];
+  }
+
+  // Expand pkey[], plen[] and value[].
+  int N = tab->u.tab.size;
+  if (N >= TABLE_MAX) {
+    *reason = "table too large";
+    return NULL;
+  }
+  {
+    char **pkey = REALLOC(tab->u.tab.key, sizeof(*pkey) * align8(N + 1));
+    int *plen = REALLOC(tab->u.tab.len, sizeof(*plen) * align8(N + 1));
+    toml_datum_t *value =
+        REALLOC(tab->u.tab.value, sizeof(*value) * align8(N + 1));
+
+    // on success, must save new pointers in tab->u.tab because the
+    // old memory areas are gone.
+    if (pkey) {
+      tab->u.tab.key = (const char **)pkey;
+    }
+    if (plen) {
+      tab->u.tab.len = plen;
+    }
+    if (value) {
+      tab->u.tab.value = value;
+    }
+
+    // if any fail, it is safe to bail out.
+    if (!pkey || !plen || !value) {
+      *reason = "out of memory";
+      return NULL;
+    }
+  }
+
+  // There is sufficient space in all the arrays for one more element.
+  // Append the new key. The value is set to DATUM_ZERO. Caller will
+  // overwrite with a valid datum.
+  tab->u.tab.size = N + 1;
+  tab->u.tab.key[N] = (char *)key.ptr;
+  tab->u.tab.len[N] = key.len;
+  tab->u.tab.value[N] = DATUM_ZERO;
+  return &tab->u.tab.value[N];
+}
+
+// Add a new key in tab. Return 0 on success, -1 otherwise.
+// On error, *reason will point to an error message.
+static int tab_add(toml_datum_t *tab, span_t newkey, toml_datum_t newvalue,
+                   const char **reason) {
+  assert(tab->type == TOML_TABLE);
+  toml_datum_t *pvalue = tab_emplace(tab, newkey, reason);
+  if (!pvalue) {
+    return -1;
+  }
+  if (pvalue->type) {
+    *reason = "duplicate key";
+    return -1;
+  }
+  *pvalue = newvalue;
+  return 0;
+}
+
+// Add a new element into an array. Return 0 on success, -1 otherwise.
+// On error, *reason will point to an error message.
+static toml_datum_t *arr_emplace(toml_datum_t *arr, const char **reason) {
+  assert(arr->type == TOML_ARRAY);
+  int n = arr->u.arr.size;
+  if (n >= ARRAY_MAX) {
+    *reason = "array too large";
+    return NULL;
+  }
+  toml_datum_t *elem = REALLOC(arr->u.arr.elem, sizeof(*elem) * align8(n + 1));
+  if (!elem) {
+    *reason = "out of memory";
+    return NULL;
+  }
+  arr->u.arr.elem = elem;
+  arr->u.arr.size = n + 1;
+  elem[n] = DATUM_ZERO;
+  return &elem[n];
+}
+
+// ------------------- parser section
+static int parse_norm(parser_t *pp, token_t tok, span_t *ret_span);
+static int parse_val(parser_t *pp, token_t tok, toml_datum_t *ret);
+static int parse_keyvalue_expr(parser_t *pp, token_t tok);
+static int parse_std_table_expr(parser_t *pp, token_t tok);
+static int parse_array_table_expr(parser_t *pp, token_t tok);
+
+static toml_datum_t mkdatum(toml_type_t ty) {
+  toml_datum_t ret = {0};
+  ret.type = ty;
+  if (ty == TOML_DATE || ty == TOML_TIME || ty == TOML_DATETIME ||
+      ty == TOML_DATETIMETZ) {
+    ret.u.ts.year = -1;
+    ret.u.ts.month = -1;
+    ret.u.ts.day = -1;
+    ret.u.ts.hour = -1;
+    ret.u.ts.minute = -1;
+    ret.u.ts.second = -1;
+    ret.u.ts.usec = -1;
+    ret.u.ts.tz = -1;
+  }
+  return ret;
+}
+
+static toml_datum_t mkdatum_at(toml_type_t ty, int lineno, int colno) {
+  toml_datum_t ret = mkdatum(ty);
+  ret.lineno = lineno;
+  ret.colno = colno;
+  return ret;
+}
+
+// Recursively free any dynamically allocated memory in the datum tree
+static void datum_free(toml_datum_t *datum) {
+  if (datum->type == TOML_TABLE) {
+    for (int i = 0, top = datum->u.tab.size; i < top; i++) {
+      datum_free(&datum->u.tab.value[i]);
+    }
+    FREE(datum->u.tab.key);
+    FREE(datum->u.tab.len);
+    FREE(datum->u.tab.value);
+  } else if (datum->type == TOML_ARRAY) {
+    for (int i = 0, top = datum->u.arr.size; i < top; i++) {
+      datum_free(&datum->u.arr.elem[i]);
+    }
+    FREE(datum->u.arr.elem);
+  }
+  // other types do not allocate memory
+  *datum = DATUM_ZERO;
+}
+
+// Make a deep copy of src to dst.
+// Return 0 on success, -1 otherwise.
+static int datum_copy(toml_datum_t *dst, toml_datum_t src, pool_t *pool,
+                      const char **reason) {
+  *dst = mkdatum_at(src.type, src.lineno, src.colno);
+  dst->flag = src.flag;
+  switch (src.type) {
+  case TOML_STRING:
+    dst->u.str.ptr = pool_alloc(pool, src.u.str.len + 1);
+    if (!dst->u.str.ptr) {
+      *reason = "out of memory";
+      goto bail;
+    }
+    dst->u.str.len = src.u.str.len;
+    memcpy((char *)dst->u.str.ptr, src.u.str.ptr, src.u.str.len + 1);
+    break;
+  case TOML_TABLE:
+    for (int i = 0; i < src.u.tab.size; i++) {
+      span_t newkey = {src.u.tab.key[i], src.u.tab.len[i]};
+      toml_datum_t *pvalue = tab_emplace(dst, newkey, reason);
+      if (!pvalue) {
+        goto bail;
+      }
+      if (datum_copy(pvalue, src.u.tab.value[i], pool, reason)) {
+        goto bail;
+      }
+    }
+    break;
+  case TOML_ARRAY:
+    for (int i = 0; i < src.u.arr.size; i++) {
+      toml_datum_t *pelem = arr_emplace(dst, reason);
+      if (!pelem) {
+        goto bail;
+      }
+      if (datum_copy(pelem, src.u.arr.elem[i], pool, reason)) {
+        goto bail;
+      }
+    }
+    break;
+  default:
+    *dst = src;
+    break;
+  }
+
+  return 0;
+
+bail:
+  datum_free(dst);
+  return -1;
+}
+
+// Check if datum is an array of tables.
+static inline bool is_array_of_tables(toml_datum_t datum) {
+  bool ret = (datum.type == TOML_ARRAY);
+  for (int i = 0; ret && i < datum.u.arr.size; i++) {
+    ret = (datum.u.arr.elem[i].type == TOML_TABLE);
+  }
+  return ret;
+}
+
+// Merge src into dst. Return 0 on success, -1 otherwise.
+static int datum_merge(toml_datum_t *dst, toml_datum_t src, pool_t *pool,
+                       const char **reason) {
+  if (dst->type != src.type) {
+    datum_free(dst);
+    return datum_copy(dst, src, pool, reason);
+  }
+  switch (src.type) {
+  case TOML_TABLE:
+    // for key-value in src:
+    //    override key-value in dst.
+    for (int i = 0; i < src.u.tab.size; i++) {
+      span_t key;
+      key.ptr = src.u.tab.key[i];
+      key.len = src.u.tab.len[i];
+      toml_datum_t *pvalue = tab_emplace(dst, key, reason);
+      if (!pvalue) {
+        return -1;
+      }
+      if (pvalue->type) {
+        DO(datum_merge(pvalue, src.u.tab.value[i], pool, reason));
+      } else {
+        datum_free(pvalue);
+        DO(datum_copy(pvalue, src.u.tab.value[i], pool, reason));
+      }
+    }
+    return 0;
+  case TOML_ARRAY:
+    if (is_array_of_tables(src)) {
+      // append src array to dst
+      for (int i = 0; i < src.u.arr.size; i++) {
+        toml_datum_t *pelem = arr_emplace(dst, reason);
+        if (!pelem) {
+          return -1;
+        }
+        DO(datum_copy(pelem, src.u.arr.elem[i], pool, reason));
+      }
+      return 0;
+    }
+    // fallthru
+  default:
+    break;
+  }
+  datum_free(dst);
+  return datum_copy(dst, src, pool, reason);
+}
+
+// Compare the content of a and b.
+static bool datum_equiv(toml_datum_t a, toml_datum_t b) {
+  if (a.type != b.type) {
+    return false;
+  }
+  int N;
+  switch (a.type) {
+  case TOML_STRING:
+    return a.u.str.len == b.u.str.len &&
+           0 == memcmp(a.u.str.ptr, b.u.str.ptr, a.u.str.len);
+  case TOML_INT64:
+    return a.u.int64 == b.u.int64;
+  case TOML_FP64:
+    return a.u.fp64 == b.u.fp64 || (isnan(a.u.fp64) && isnan(b.u.fp64));
+  case TOML_BOOLEAN:
+    return !!a.u.boolean == !!b.u.boolean;
+  case TOML_DATE:
+    return a.u.ts.year == b.u.ts.year && a.u.ts.month == b.u.ts.month &&
+           a.u.ts.day == b.u.ts.day;
+  case TOML_TIME:
+    return a.u.ts.hour == b.u.ts.hour && a.u.ts.minute == b.u.ts.minute &&
+           a.u.ts.second == b.u.ts.second && a.u.ts.usec == b.u.ts.usec;
+  case TOML_DATETIME:
+    return a.u.ts.year == b.u.ts.year && a.u.ts.month == b.u.ts.month &&
+           a.u.ts.day == b.u.ts.day && a.u.ts.hour == b.u.ts.hour &&
+           a.u.ts.minute == b.u.ts.minute && a.u.ts.second == b.u.ts.second &&
+           a.u.ts.usec == b.u.ts.usec;
+  case TOML_DATETIMETZ:
+    return a.u.ts.year == b.u.ts.year && a.u.ts.month == b.u.ts.month &&
+           a.u.ts.day == b.u.ts.day && a.u.ts.hour == b.u.ts.hour &&
+           a.u.ts.minute == b.u.ts.minute && a.u.ts.second == b.u.ts.second &&
+           a.u.ts.usec == b.u.ts.usec && a.u.ts.tz == b.u.ts.tz;
+  case TOML_ARRAY:
+    N = a.u.arr.size;
+    if (N != b.u.arr.size) {
+      return false;
+    }
+    for (int i = 0; i < N; i++) {
+      if (!datum_equiv(a.u.arr.elem[i], b.u.arr.elem[i])) {
+        return false;
+      }
+    }
+    return true;
+  case TOML_TABLE:
+    N = a.u.tab.size;
+    if (N != b.u.tab.size) {
+      return false;
+    }
+    for (int i = 0; i < N; i++) {
+      int len = a.u.tab.len[i];
+      if (len != b.u.tab.len[i]) {
+        return false;
+      }
+      if (0 != memcmp(a.u.tab.key[i], b.u.tab.key[i], len)) {
+        return false;
+      }
+      if (!datum_equiv(a.u.tab.value[i], b.u.tab.value[i])) {
+        return false;
+      }
+    }
+    return true;
+  default:
+    break;
+  }
+  return false;
+}
+
+/**
+ *  Override values in r1 using r2. Return a new result. All results
+ *  (i.e., r1, r2 and the returned result) must be freed using toml_free()
+ *  after use.
+ *
+ *  LOGIC:
+ *   ret = copy of r1
+ *   for each item x in r2:
+ *     if x is not in ret:
+ *          override
+ *     elif x in ret is NOT of the same type:
+ *         override
+ *     elif x is an array of tables:
+ *         append r2.x to ret.x
+ *     elif x is a table:
+ *         merge r2.x to ret.x
+ *     else:
+ *         override
+ */
+toml_result_t toml_merge(const toml_result_t *r1, const toml_result_t *r2) {
+  const char *reason = "";
+  toml_result_t ret = {0};
+  pool_t *pool = 0;
+  if (!r1->ok) {
+    reason = "param error: r1 not ok";
+    goto bail;
+  }
+  if (!r2->ok) {
+    reason = "param error: r2 not ok";
+    goto bail;
+  }
+  {
+    pool_t *r1pool = (pool_t *)r1->__internal;
+    pool_t *r2pool = (pool_t *)r2->__internal;
+    pool = pool_create(r1pool->top + r2pool->top);
+    if (!pool) {
+      reason = "out of memory";
+      goto bail;
+    }
+  }
+
+  // Make a copy of r1
+  if (datum_copy(&ret.toptab, r1->toptab, pool, &reason)) {
+    goto bail;
+  }
+
+  // Merge r2 into the result
+  if (datum_merge(&ret.toptab, r2->toptab, pool, &reason)) {
+    goto bail;
+  }
+
+  ret.ok = 1;
+  ret.__internal = pool;
+  return ret;
+
+bail:
+  pool_destroy(pool);
+  snprintf(ret.errmsg, sizeof(ret.errmsg), "%s", reason);
+  return ret;
+}
+
+bool toml_equiv(const toml_result_t *r1, const toml_result_t *r2) {
+  if (!(r1->ok && r2->ok)) {
+    return false;
+  }
+  return datum_equiv(r1->toptab, r2->toptab);
+}
+
+/**
+ * Find a key in a toml_table. Return the value of the key if found,
+ * or a TOML_UNKNOWN otherwise.
+ */
+toml_datum_t toml_get(toml_datum_t datum, const char *key) {
+  if (datum.type == TOML_TABLE) {
+    int n = datum.u.tab.size;
+    const char **pkey = datum.u.tab.key;
+    toml_datum_t *pvalue = datum.u.tab.value;
+    for (int i = 0; i < n; i++) {
+      if (0 == strcmp(pkey[i], key)) {
+        return pvalue[i];
+      }
+    }
+  }
+  return DATUM_ZERO;
+}
+
+/**
+ * Locate a value starting from a toml_table. Return the value of the key if
+ * found, or a TOML_UNKNOWN otherwise.
+ *
+ * Note: the multipart-key is separated by DOT, and must not have any escape
+ * chars.
+ */
+toml_datum_t toml_seek(toml_datum_t table, const char *multipart_key) {
+  if (table.type != TOML_TABLE) {
+    return DATUM_ZERO;
+  }
+
+  // Make a mutable copy of the multipart_key for splitting
+  char buf[256];
+  if (copystring(buf, sizeof(buf), multipart_key)) {
+    // if the multipart_key is longer than buffer, just
+    // signal a not-found.
+    return DATUM_ZERO;
+  }
+
+  // Go through the multipart name part by part.
+  char *p = buf;
+  toml_datum_t datum = table;
+  while (datum.type == TOML_TABLE) {
+    char *q = strchr(p, '.');
+    if (q) {
+      // traverse to next key
+      *q = 0;
+      datum = toml_get(datum, p);
+      p = q + 1;
+      continue;
+    }
+
+    // At end of last keypart.
+    // look up p in the final table
+    return toml_get(datum, p);
+  }
+
+  return DATUM_ZERO;
+}
+
+/**
+ *  Return the default options.
+ */
+toml_option_t toml_default_option(void) {
+  toml_option_t opt = {0, realloc, free};
+  return opt;
+}
+
+/**
+ *  Override the current options.
+ */
+void toml_set_option(toml_option_t opt) { toml_option = opt; }
+
+/**
+ *  Free the result returned by toml_parse().
+ */
+void toml_free(toml_result_t result) {
+  datum_free(&result.toptab);
+  pool_destroy((pool_t *)result.__internal);
+}
+
+/**
+ *  Parse a toml document.
+ */
+toml_result_t toml_parse_file_ex(const char *fname) {
+  toml_result_t result = {0};
+  FILE *fp = fopen(fname, "r");
+  if (!fp) {
+    snprintf(result.errmsg, sizeof(result.errmsg), "fopen %s: %s", fname,
+             strerror(errno));
+    return result;
+  }
+  result = toml_parse_file(fp);
+  fclose(fp);
+  return result;
+}
+
+/**
+ *  Parse a toml document.
+ */
+toml_result_t toml_parse_file(FILE *fp) {
+  toml_result_t result = {0};
+  char *buf = 0;
+  int top, max; // index into buf[]
+  top = max = 0;
+
+  // Read file into memory
+  while (!feof(fp)) {
+    assert(top <= max);
+    if (top == max) {
+      // need to extend buf[]
+      int64_t tmpmax64 = (int64_t)max * 3 / 2 + 1000;
+      int tmpmax = (tmpmax64 > INT_MAX - 1) ? INT_MAX - 1 : (int)tmpmax64;
+      if (tmpmax == INT_MAX - 1) {
+        snprintf(result.errmsg, sizeof(result.errmsg), "file is too big");
+        FREE(buf);
+        return result;
+      }
+      // add an extra byte for terminating NUL
+      char *tmp = REALLOC(buf, tmpmax + 1);
+      if (!tmp) {
+        snprintf(result.errmsg, sizeof(result.errmsg), "out of memory");
+        FREE(buf);
+        return result;
+      }
+      buf = tmp;
+      max = tmpmax;
+    }
+
+    errno = 0;
+    top += fread(buf + top, 1, max - top, fp);
+    if (ferror(fp)) {
+      snprintf(result.errmsg, sizeof(result.errmsg), "%s",
+               errno ? strerror(errno) : "Error reading file");
+      FREE(buf);
+      return result;
+    }
+  }
+  buf[top] = 0; // NUL terminator
+
+  result = toml_parse(buf, top);
+  FREE(buf);
+  return result;
+}
+
+/**
+ *  Parse a toml document.
+ */
+toml_result_t toml_parse(const char *src, int len) {
+  toml_result_t result = {0};
+  parser_t parser = {0};
+  parser_t *pp = &parser;
+
+  // Check that src is not NULL.
+  if (!src) {
+    snprintf(result.errmsg, sizeof(result.errmsg), "src is NULL");
+    goto bail;
+  }
+
+  // Check that src is NUL terminated.
+  if (src[len]) {
+    snprintf(result.errmsg, sizeof(result.errmsg),
+             "src[] must be NUL terminated");
+    goto bail;
+  }
+
+  // If user insists, check that src[] is a valid utf8 string.
+  if (toml_option.check_utf8) {
+    int line = 1; // keeps track of line number
+    for (int i = 0; i < len;) {
+      uint32_t ch;
+      int n = utf8_to_ucs(src + i, len - i, &ch);
+      if (n < 0) {
+        snprintf(result.errmsg, sizeof(result.errmsg),
+                 "invalid UTF8 char on line %d", line);
+        goto bail;
+      }
+      if (0xD800 <= ch && ch <= 0xDFFF) {
+        // explicitly prohibit surrogates (non-scalar unicode code point)
+        snprintf(result.errmsg, sizeof(result.errmsg),
+                 "invalid UTF8 char \\u%04x on line %d", ch, line);
+        goto bail;
+      }
+      line += (ch == '\n' ? 1 : 0);
+      i += n;
+    }
+  }
+
+  // Initialize parser
+  pp->toptab = mkdatum_at(TOML_TABLE, 1, 1);
+  pp->curtab = &pp->toptab;
+  pp->ebuf.ptr = result.errmsg; // parse error will be printed into pp->ebuf
+  pp->ebuf.len = sizeof(result.errmsg);
+
+  // Alloc memory pool
+  pp->pool =
+      pool_create(len + 10); // add some extra bytes for NUL term and safety
+  if (!pp->pool) {
+    snprintf(result.errmsg, sizeof(result.errmsg), "out of memory");
+    goto bail;
+  }
+
+  // Initialize scanner. Scan error will be printed into pp->ebuf.
+  scan_init(&pp->scanner, src, len, pp->ebuf.ptr, pp->ebuf.len);
+
+  // Keep parsing until FIN
+  for (;;) {
+    token_t tok;
+    if (scan_key(&pp->scanner, &tok)) {
+      goto bail;
+    }
+    // break on FIN
+    if (tok.toktyp == TOK_FIN) {
+      break;
+    }
+    switch (tok.toktyp) {
+    case TOK_ENDL: // skip blank lines
+      continue;
+    case TOK_LBRACK:
+      if (parse_std_table_expr(pp, tok)) {
+        goto bail;
+      }
+      break;
+    case TOK_LLBRACK:
+      if (parse_array_table_expr(pp, tok)) {
+        goto bail;
+      }
+      break;
+    default:
+      // non-blank line: parse an expression
+      if (parse_keyvalue_expr(pp, tok)) {
+        goto bail;
+      }
+      break;
+    }
+    // each expression must be followed by newline
+    if (scan_key(&pp->scanner, &tok)) {
+      goto bail;
+    }
+    if (tok.toktyp == TOK_FIN || tok.toktyp == TOK_ENDL) {
+      continue;
+    }
+    SETERROR(pp->ebuf, tok.lineno, "ENDL expected");
+    goto bail;
+  }
+
+  // return result
+  result.ok = true;
+  result.toptab = pp->toptab;
+  result.__internal = (void *)pp->pool;
+  return result;
+
+bail:
+  // return error
+  datum_free(&pp->toptab);
+  pool_destroy(pp->pool);
+  result.ok = false;
+  if (result.errmsg[0] == '\0') {
+    assert(0);
+    snprintf(result.errmsg, sizeof(result.errmsg), "Error near line %d\n",
+             pp->scanner.lineno);
+  }
+  return result;
+}
+
+// Convert a (LITSTRING, LIT, MLLITSTRING, MLSTRING, or STRING) token to a
+// datum.
+static int token_to_string(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  *ret = mkdatum_at(TOML_STRING, tok.lineno, tok.colno);
+  span_t span;
+  DO(parse_norm(pp, tok, &span));
+  ret->u.str.ptr = (char *)span.ptr;
+  ret->u.str.len = span.len;
+  return 0;
+}
+
+// Convert a TIME/DATE/DATETIME/DATETIMETZ to a datum
+static int token_to_timestamp(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  (void)pp;
+  static const toml_type_t map[] = {[TOK_TIME] = TOML_TIME,
+                                    [TOK_DATE] = TOML_DATE,
+                                    [TOK_DATETIME] = TOML_DATETIME,
+                                    [TOK_DATETIMETZ] = TOML_DATETIMETZ};
+  switch (tok.toktyp) {
+  case TOK_TIME:
+  case TOK_DATE:
+  case TOK_DATETIME:
+  case TOK_DATETIMETZ:
+    break;
+  default:
+    assert(0 && "unexpected token type");
+    return -1;
+  }
+
+  *ret = mkdatum_at(map[tok.toktyp], tok.lineno, tok.colno);
+  ret->u.ts.year = tok.u.tsval.year;
+  ret->u.ts.month = tok.u.tsval.month;
+  ret->u.ts.day = tok.u.tsval.day;
+  ret->u.ts.hour = tok.u.tsval.hour;
+  ret->u.ts.minute = tok.u.tsval.minute;
+  ret->u.ts.second = tok.u.tsval.sec;
+  ret->u.ts.usec = tok.u.tsval.usec;
+  ret->u.ts.tz = tok.u.tsval.tz;
+  return 0;
+}
+
+// Convert an int64 token to a datum.
+static int token_to_int64(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  (void)pp;
+  assert(tok.toktyp == TOK_INTEGER);
+  *ret = mkdatum_at(TOML_INT64, tok.lineno, tok.colno);
+  ret->u.int64 = tok.u.int64;
+  return 0;
+}
+
+// Convert a fp64 token to a datum.
+static int token_to_fp64(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  (void)pp;
+  assert(tok.toktyp == TOK_FLOAT);
+  *ret = mkdatum_at(TOML_FP64, tok.lineno, tok.colno);
+  ret->u.fp64 = tok.u.fp64;
+  return 0;
+}
+
+// Convert a boolean token to a datum.
+static int token_to_boolean(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  (void)pp;
+  assert(tok.toktyp == TOK_BOOL);
+  *ret = mkdatum_at(TOML_BOOLEAN, tok.lineno, tok.colno);
+  ret->u.boolean = tok.u.b1;
+  return 0;
+}
+
+// Parse a multipart key. Return 0 on success, -1 otherwise.
+static int parse_key(parser_t *pp, token_t tok, keypart_t *ret_keypart) {
+  ret_keypart->nspan = 0;
+  // key = simple-key | dotted_key
+  // simple-key = STRING | LITSTRING | LIT
+  // dotted-key = simple-key (DOT simple-key)+
+  if (tok.toktyp != TOK_STRING && tok.toktyp != TOK_LITSTRING &&
+      tok.toktyp != TOK_LIT) {
+    return SETERROR(pp->ebuf, tok.lineno, "missing key");
+  }
+
+  int n = 0;
+  span_t *kpspan = ret_keypart->span;
+
+  // Normalize the first keypart
+  if (parse_norm(pp, tok, &kpspan[n])) {
+    return SETERROR(pp->ebuf, tok.lineno,
+                    "unable to normalize string; probably a unicode issue");
+  }
+  n++;
+
+  // Scan and normalize the second to last keypart
+  while (1) {
+    scanner_state_t mark = scan_mark(&pp->scanner);
+
+    // Eat the dot if it is there
+    DO(scan_key(&pp->scanner, &tok));
+
+    // If not a dot, we are done with keyparts.
+    if (tok.toktyp != TOK_DOT) {
+      scan_restore(&pp->scanner, mark);
+      break;
+    }
+
+    // Scan the n-th key
+    DO(scan_key(&pp->scanner, &tok));
+
+    if (tok.toktyp != TOK_STRING && tok.toktyp != TOK_LITSTRING &&
+        tok.toktyp != TOK_LIT) {
+      return SETERROR(pp->ebuf, tok.lineno, "expects a string in dotted-key");
+    }
+
+    if (n >= KEYPARTMAX) {
+      return SETERROR(pp->ebuf, tok.lineno, "too many key parts");
+    }
+
+    // Normalize the n-th key.
+    DO(parse_norm(pp, tok, &kpspan[n]));
+    n++;
+  }
+
+  // This key has n parts.
+  ret_keypart->nspan = n;
+  return 0;
+}
+
+// Starting at toptab, descend following keypart[]. If a key does not
+// exist in the current table, create a new table entry for the
+// key. Returns the final table represented by the key.
+static toml_datum_t *descend_keypart(parser_t *pp, int lineno, int colno,
+                                     toml_datum_t *toptab, keypart_t *keypart,
+                                     bool stdtabexpr) {
+  toml_datum_t *tab = toptab; // current tab
+
+  for (int i = 0; i < keypart->nspan; i++) {
+    const char *reason;
+    // Find the i-th keypart
+    int j = tab_find(tab, keypart->span[i]);
+    // Not found: add a new (key, tab) pair.
+    if (j < 0) {
+      toml_datum_t newtab = mkdatum_at(TOML_TABLE, lineno, colno);
+      newtab.flag |= stdtabexpr ? FLAG_STDEXPR : 0;
+      if (tab_add(tab, keypart->span[i], newtab, &reason)) {
+        SETERROR(pp->ebuf, lineno, "%s", reason);
+        return NULL;
+      }
+      tab = &tab->u.tab.value[tab->u.tab.size - 1]; // descend
+      continue;
+    }
+
+    // Found: extract the value of the key.
+    toml_datum_t *value = &tab->u.tab.value[j];
+
+    // If the value is a table, descend.
+    if (value->type == TOML_TABLE) {
+      tab = value; // descend
+      continue;
+    }
+
+    // If the value is an array: locate the last entry and descend.
+    if (value->type == TOML_ARRAY) {
+      // If empty: error.
+      if (value->u.arr.size <= 0) {
+        SETERROR(pp->ebuf, lineno, "array %s has no elements",
+                 keypart->span[i].ptr);
+        return NULL;
+      }
+
+      // Extract the last element of the array.
+      value = &value->u.arr.elem[value->u.arr.size - 1];
+
+      // It must be a table!
+      if (value->type != TOML_TABLE) {
+        SETERROR(pp->ebuf, lineno, "array %s must be array of tables",
+                 keypart->span[i].ptr);
+        return NULL;
+      }
+      tab = value; // descend
+      continue;
+    }
+
+    // key not found
+    SETERROR(pp->ebuf, lineno, "cannot locate table at key %s",
+             keypart->span[i].ptr);
+    return NULL;
+  }
+
+  // Return the table corresponding to the keypart[].
+  return tab;
+}
+
+// Recursively set flags on datum
+static void set_flag_recursive(toml_datum_t *datum, uint32_t flag) {
+  datum->flag |= flag;
+  switch (datum->type) {
+  case TOML_ARRAY:
+    for (int i = 0, top = datum->u.arr.size; i < top; i++) {
+      set_flag_recursive(&datum->u.arr.elem[i], flag);
+    }
+    break;
+  case TOML_TABLE:
+    for (int i = 0, top = datum->u.tab.size; i < top; i++) {
+      set_flag_recursive(&datum->u.tab.value[i], flag);
+    }
+    break;
+  default:
+    break;
+  }
+}
+
+// Parse an inline array.
+static int parse_inline_array(parser_t *pp, token_t tok,
+                              toml_datum_t *ret_datum) {
+  assert(tok.toktyp == TOK_LBRACK);
+  *ret_datum = mkdatum_at(TOML_ARRAY, tok.lineno, tok.colno);
+  int need_comma = 0;
+
+  // loop until RBRACK
+  for (;;) {
+    // skip ENDL
+    do {
+      DO(scan_value(&pp->scanner, &tok));
+    } while (tok.toktyp == TOK_ENDL);
+
+    // If got an RBRACK: done!
+    if (tok.toktyp == TOK_RBRACK) {
+      break;
+    }
+
+    // If got a COMMA: check if it is expected.
+    if (tok.toktyp == TOK_COMMA) {
+      if (need_comma) {
+        need_comma = 0;
+        continue;
+      }
+      return SETERROR(pp->ebuf, tok.lineno,
+                      "syntax error while parsing array: unexpected comma");
+    }
+
+    // Not a comma, but need a comma: error!
+    if (need_comma) {
+      return SETERROR(pp->ebuf, tok.lineno,
+                      "syntax error while parsing array: missing comma");
+    }
+
+    // This is a valid value! Obtain the value.
+    toml_datum_t value = DATUM_ZERO;
+    if (parse_val(pp, tok, &value)) {
+      datum_free(&value);
+      return -1;
+    }
+
+    // Add the value to the array.
+    const char *reason;
+    toml_datum_t *pelem = arr_emplace(ret_datum, &reason);
+    if (!pelem) {
+      datum_free(&value);
+      return SETERROR(pp->ebuf, tok.lineno, "while parsing array: %s", reason);
+    }
+    *pelem = value;
+
+    // Need comma before the next value.
+    need_comma = 1;
+  }
+
+  // Set the INLINE flag for all things in this array.
+  set_flag_recursive(ret_datum, FLAG_INLINED);
+  return 0;
+}
+
+// Parse an inline table.
+static int parse_inline_table(parser_t *pp, token_t tok,
+                              toml_datum_t *ret_datum) {
+  assert(tok.toktyp == TOK_LBRACE);
+  *ret_datum = mkdatum_at(TOML_TABLE, tok.lineno, tok.colno);
+  bool need_comma = 0;
+  bool was_comma = 0;
+
+  // loop until RBRACE
+  for (;;) {
+    DO(scan_key(&pp->scanner, &tok));
+
+    // Got an RBRACE: done!
+    if (tok.toktyp == TOK_RBRACE) {
+      if (was_comma) {
+        /*
+        return SETERROR(pp->ebuf, tok.lineno,
+                        "extra comma before closing brace");
+        */
+        // extra comma before RBRACE is allowed for v1.1
+        (void)0;
+      }
+      break;
+    }
+
+    // Got a comma: check if it is expected.
+    if (tok.toktyp == TOK_COMMA) {
+      if (need_comma) {
+        need_comma = 0, was_comma = 1;
+        continue;
+      }
+      return SETERROR(pp->ebuf, tok.lineno, "unexpected comma");
+    }
+
+    // Newline not allowed in inline table.
+    // newline is allowed in v1.1
+    if (tok.toktyp == TOK_ENDL) {
+      // return SETERROR(pp->ebuf, tok.lineno, "unexpected newline");
+      continue;
+    }
+
+    // Not a comma, but need a comma: error!
+    if (need_comma) {
+      return SETERROR(pp->ebuf, tok.lineno, "missing comma");
+    }
+
+    // Get the keyparts
+    keypart_t keypart = {0};
+    int keylineno = tok.lineno;
+    int keycolno = tok.colno;
+    DO(parse_key(pp, tok, &keypart));
+
+    // Descend to one keypart before last
+    assert(keypart.nspan > 0);
+    span_t lastkeypart = keypart.span[--keypart.nspan];
+    toml_datum_t *tab =
+        descend_keypart(pp, keylineno, keycolno, ret_datum, &keypart, false);
+    if (!tab) {
+      return -1;
+    }
+
+    // If tab is a previously declared inline table: error.
+    if (tab->flag & FLAG_INLINED) {
+      return SETERROR(pp->ebuf, tok.lineno, "inline table cannot be extended");
+    }
+
+    // We are explicitly defining it now.
+    tab->flag |= FLAG_EXPLICIT;
+
+    // match EQUAL
+    DO(scan_value(&pp->scanner, &tok));
+
+    if (tok.toktyp != TOK_EQUAL) {
+      if (tok.toktyp == TOK_ENDL) {
+        return SETERROR(pp->ebuf, tok.lineno, "unexpected newline");
+      } else {
+        return SETERROR(pp->ebuf, tok.lineno, "missing '='");
+      }
+    }
+
+    // obtain the value
+    DO(scan_value(&pp->scanner, &tok));
+    toml_datum_t value = DATUM_ZERO;
+    if (parse_val(pp, tok, &value)) {
+      datum_free(&value);
+      return -1;
+    }
+
+    // Add the value to tab.
+    const char *reason;
+    if (tab_add(tab, lastkeypart, value, &reason)) {
+      datum_free(&value);
+      return SETERROR(pp->ebuf, tok.lineno, "%s", reason);
+    }
+    need_comma = 1, was_comma = 0;
+  }
+
+  set_flag_recursive(ret_datum, FLAG_INLINED);
+  return 0;
+}
+
+// Parse a value.
+static int parse_val(parser_t *pp, token_t tok, toml_datum_t *ret) {
+  *ret = DATUM_ZERO; // initialize
+
+  // val = string / boolean / array / inline-table / date-time / float / integer
+  switch (tok.toktyp) {
+  case TOK_STRING:
+  case TOK_MLSTRING:
+  case TOK_LITSTRING:
+  case TOK_MLLITSTRING:
+    return token_to_string(pp, tok, ret);
+  case TOK_TIME:
+  case TOK_DATE:
+  case TOK_DATETIME:
+  case TOK_DATETIMETZ:
+    return token_to_timestamp(pp, tok, ret);
+  case TOK_INTEGER:
+    return token_to_int64(pp, tok, ret);
+  case TOK_FLOAT:
+    return token_to_fp64(pp, tok, ret);
+  case TOK_BOOL:
+    return token_to_boolean(pp, tok, ret);
+  case TOK_LBRACK: // inline-array
+    return parse_inline_array(pp, tok, ret);
+  case TOK_LBRACE: // inline-table
+    return parse_inline_table(pp, tok, ret);
+  default:
+    return SETERROR(pp->ebuf, tok.lineno, "missing value");
+  }
+}
+
+// Parse a standard table expression, and set the curtab of the parser
+// to the table referenced.  A standard table expression is a line
+// like [a.b.c.d].
+static int parse_std_table_expr(parser_t *pp, token_t tok) {
+  // std-table = [ key ]
+  // Eat the [
+  assert(tok.toktyp == TOK_LBRACK); // [ ate by caller
+
+  // Read the first keypart
+  DO(scan_key(&pp->scanner, &tok));
+
+  // Extract the keypart[]
+  int keylineno = tok.lineno;
+  int keycolno = tok.colno;
+  keypart_t keypart;
+  DO(parse_key(pp, tok, &keypart));
+
+  // Eat the ]
+  DO(scan_key(&pp->scanner, &tok));
+  if (tok.toktyp != TOK_RBRACK) {
+    return SETERROR(pp->ebuf, tok.lineno, "missing right-bracket");
+  }
+
+  // Descend to one keypart before last.
+  span_t lastkeypart = keypart.span[--keypart.nspan];
+
+  // Descend keypart from the toptab.
+  toml_datum_t *tab =
+      descend_keypart(pp, keylineno, keycolno, &pp->toptab, &keypart, true);
+  if (!tab) {
+    return -1;
+  }
+
+  // Look for the last keypart in the final tab
+  int j = tab_find(tab, lastkeypart);
+  if (j < 0) {
+    // If not found: add it.
+    if (tab->flag & FLAG_INLINED) {
+      return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
+    }
+    const char *reason;
+    toml_datum_t newtab = mkdatum_at(TOML_TABLE, keylineno, keycolno);
+    newtab.flag |= FLAG_STDEXPR;
+    if (tab_add(tab, lastkeypart, newtab, &reason)) {
+      return SETERROR(pp->ebuf, keylineno, "%s", reason);
+    }
+    // this is the new tab
+    tab = &tab->u.tab.value[tab->u.tab.size - 1];
+  } else {
+    // Found: check for errors
+    tab = &tab->u.tab.value[j];
+    if (tab->flag & FLAG_EXPLICIT) {
+      /*
+        This is not OK:
+        [x.y.z]
+        [x.y.z]
+
+        but this is OK:
+        [x.y.z]
+        [x]
+      */
+      return SETERROR(pp->ebuf, keylineno, "table defined more than once");
+    }
+    if (!(tab->flag & FLAG_STDEXPR)) {
+      /*
+      [t1]			# OK
+      t2.t3.v = 0		# OK
+      [t1.t2]   		# should FAIL  - t2 was non-explicit but was not
+      created by std-table-expr
+      */
+      return SETERROR(pp->ebuf, keylineno, "table defined before");
+    }
+  }
+
+  // Set explicit flag on tab
+  tab->flag |= FLAG_EXPLICIT;
+  tab->lineno = keylineno;
+  tab->colno = keycolno;
+
+  // Set tab as curtab of the parser
+  pp->curtab = tab;
+  return 0;
+}
+
+// Parse an array table expression, and set the curtab of the parser
+// to the table referenced. A standard array table expression is a line
+// like [[a.b.c.d]].
+static int parse_array_table_expr(parser_t *pp, token_t tok) {
+  // array-table = [[ key ]]
+  assert(tok.toktyp == TOK_LLBRACK); // [[ ate by caller
+
+  // Read the first keypart
+  DO(scan_key(&pp->scanner, &tok));
+
+  int keylineno = tok.lineno;
+  int keycolno = tok.colno;
+  keypart_t keypart;
+  DO(parse_key(pp, tok, &keypart));
+
+  // eat the ]]
+  token_t rrb;
+  DO(scan_key(&pp->scanner, &rrb));
+  if (rrb.toktyp != TOK_RRBRACK) {
+    return SETERROR(pp->ebuf, rrb.lineno, "missing ']]'");
+  }
+
+  // remove the last keypart from keypart[]
+  assert(keypart.nspan > 0);
+  span_t lastkeypart = keypart.span[--keypart.nspan];
+
+  // descend intermediate keys from toptab
+  toml_datum_t *tab =
+      descend_keypart(pp, keylineno, keycolno, &pp->toptab, &keypart, true);
+  if (!tab)
+    return -1;
+
+  // For the final keypart, make sure entry at key is an array of tables
+  const char *reason;
+  int idx = tab_find(tab, lastkeypart);
+  if (idx == -1) {
+    // If not found, add an array of table.
+    if (tab->flag & FLAG_INLINED) {
+      return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
+    }
+    toml_datum_t newarr = mkdatum_at(TOML_ARRAY, keylineno, keycolno);
+    if (tab_add(tab, lastkeypart, newarr, &reason)) {
+      return SETERROR(pp->ebuf, keylineno, "%s", reason);
+    }
+    idx = tab_find(tab, lastkeypart);
+    assert(idx >= 0);
+  }
+  // Check that this is an array.
+  if (tab->u.tab.value[idx].type != TOML_ARRAY) {
+    return SETERROR(pp->ebuf, keylineno, "entry must be an array");
+  }
+  // Add an empty table to the array
+  toml_datum_t *arr = &tab->u.tab.value[idx];
+  if (arr->flag & FLAG_INLINED) {
+    return SETERROR(pp->ebuf, keylineno, "cannot extend a static array");
+  }
+  toml_datum_t *pelem = arr_emplace(arr, &reason);
+  if (!pelem) {
+    return SETERROR(pp->ebuf, keylineno, "%s", reason);
+  }
+  *pelem = mkdatum_at(TOML_TABLE, keylineno, keycolno);
+
+  // Set the last element of this array as curtab of the parser
+  pp->curtab = &arr->u.arr.elem[arr->u.arr.size - 1];
+  assert(pp->curtab->type == TOML_TABLE);
+
+  return 0;
+}
+
+// Parse an expression. A toml doc is just a list of expressions.
+static int parse_keyvalue_expr(parser_t *pp, token_t tok) {
+  // Obtain the key
+  int keylineno = tok.lineno;
+  int keycolno = tok.colno;
+  keypart_t keypart;
+  DO(parse_key(pp, tok, &keypart));
+
+  // match the '='
+  DO(scan_key(&pp->scanner, &tok));
+  if (tok.toktyp != TOK_EQUAL) {
+    return SETERROR(pp->ebuf, tok.lineno, "expect '='");
+  }
+
+  // Locate the last table using keypart[]
+  const char *reason;
+  toml_datum_t *tab = pp->curtab;
+  for (int i = 0; i < keypart.nspan - 1; i++) {
+    int j = tab_find(tab, keypart.span[i]);
+    if (j < 0) {
+      if (i > 0 && (tab->flag & FLAG_EXPLICIT)) {
+        return SETERROR(
+            pp->ebuf, keylineno,
+            "cannot extend a previously defined table using dotted expression");
+      }
+      toml_datum_t newtab = mkdatum_at(TOML_TABLE, keylineno, keycolno);
+      if (tab_add(tab, keypart.span[i], newtab, &reason)) {
+        return SETERROR(pp->ebuf, keylineno, "%s", reason);
+      }
+      tab = &tab->u.tab.value[tab->u.tab.size - 1];
+      continue;
+    }
+    toml_datum_t *value = &tab->u.tab.value[j];
+    if (value->type == TOML_TABLE) {
+      tab = value;
+      continue;
+    }
+    if (value->type == TOML_ARRAY) {
+      return SETERROR(pp->ebuf, keylineno,
+                      "encountered previously declared array '%s'",
+                      keypart.span[i].ptr);
+    }
+    return SETERROR(pp->ebuf, keylineno, "cannot locate table at '%s'",
+                    keypart.span[i].ptr);
+  }
+
+  // Check for disallowed situations.
+  if (tab->flag & FLAG_INLINED) {
+    return SETERROR(pp->ebuf, keylineno, "inline table cannot be extended");
+  }
+  if (keypart.nspan > 1 && (tab->flag & FLAG_EXPLICIT)) {
+    return SETERROR(
+        pp->ebuf, keylineno,
+        "cannot extend a previously defined table using dotted expression");
+  }
+
+  // Obtain the value
+  DO(scan_value(&pp->scanner, &tok));
+  toml_datum_t newval = DATUM_ZERO;
+  if (parse_val(pp, tok, &newval)) {
+    datum_free(&newval);
+    return -1;
+  }
+
+  // Add a new key/value for tab.
+  if (tab_add(tab, keypart.span[keypart.nspan - 1], newval, &reason)) {
+    datum_free(&newval);
+    return SETERROR(pp->ebuf, keylineno, "%s", reason);
+  }
+
+  return 0;
+}
+
+// Normalize a LIT/STRING/MLSTRING/LITSTRING/MLLITSTRING
+// -> unescape all escaped chars
+// The returned string is allocated out of pp->pool
+static int parse_norm(parser_t *pp, token_t tok, span_t *ret_span) {
+  // Allocate a buffer to store the normalized string. Add one
+  // extra-byte for terminating NUL.
+  char *p = pool_alloc(pp->pool, tok.str.len + 1);
+  if (!p) {
+    return SETERROR(pp->ebuf, tok.lineno, "out of memory");
+  }
+
+  // Copy from token string into buffer
+  memcpy(p, tok.str.ptr, tok.str.len);
+  p[tok.str.len] = 0; // additional NUL term for safety
+
+  ret_span->ptr = p;
+  ret_span->len = tok.str.len;
+
+  switch (tok.toktyp) {
+  case TOK_LIT:
+  case TOK_LITSTRING:
+  case TOK_MLLITSTRING:
+    // no need to handle escape chars
+    return 0;
+
+  case TOK_STRING:
+  case TOK_MLSTRING:
+    // need to handle escape chars
+    break;
+
+  default:
+    return SETERROR(pp->ebuf, 0, "internal: arg must be a string");
+  }
+
+  // if there is no escape char, then done!
+  if (!tok.u.escp) {
+    return 0; // success
+  }
+
+  // p points to the backslash
+  p += (tok.u.escp - tok.str.ptr);
+  assert(p - ret_span->ptr == tok.u.escp - tok.str.ptr);
+  assert(*p == '\\');
+
+  // Normalize the escaped chars
+  char *dst = p;
+  while (*p) {
+    if (*p != '\\') {
+      *dst++ = *p++;
+      continue;
+    }
+    switch (p[1]) {
+    case '"':
+    case '\\':
+      *dst++ = p[1];
+      p += 2;
+      continue;
+    case 'b':
+      *dst++ = '\b';
+      p += 2;
+      continue;
+    case 't':
+      *dst++ = '\t';
+      p += 2;
+      continue;
+    case 'n':
+      *dst++ = '\n';
+      p += 2;
+      continue;
+    case 'f':
+      *dst++ = '\f';
+      p += 2;
+      continue;
+    case 'r':
+      *dst++ = '\r';
+      p += 2;
+      continue;
+    case 'e':
+      *dst++ = '\033';
+      p += 2;
+      continue;
+    case 'x': {
+      char buf[3];
+      memcpy(buf, p + 2, 2);
+      buf[2] = 0;
+      // There is no need to check for two hex digits here because
+      // the scanner already checked it.
+      int32_t ucs = strtol(buf, 0, 16);
+      int n = ucs_to_utf8(ucs, dst);
+      if (n < 0) {
+        return SETERROR(pp->ebuf, tok.lineno, "error converting UCS %s to UTF8",
+                        buf);
+      }
+      dst += n;
+      p += 2 + 2; // \xNN
+      continue;
+    }
+    case 'u':
+    case 'U': {
+      char buf[9];
+      int sz = (p[1] == 'u' ? 4 : 8);
+      memcpy(buf, p + 2, sz);
+      buf[sz] = 0;
+      // There is no need to check for 4 or 8 hex digits here because
+      // the scanner already checked it.
+      int32_t ucs = strtol(buf, 0, 16);
+      if (0xD800 <= ucs && ucs <= 0xDFFF) {
+        // explicitly prohibit surrogates (non-scalar unicode code point)
+        return SETERROR(pp->ebuf, tok.lineno, "invalid UTF8 char \\u%04x", ucs);
+      }
+      int n = ucs_to_utf8(ucs, dst);
+      if (n < 0) {
+        return SETERROR(pp->ebuf, tok.lineno, "error converting UCS %s to UTF8",
+                        buf);
+      }
+      dst += n;
+      p += 2 + sz; // \uNNNN or \UNNNNNNNN
+      continue;
+    }
+
+    case ' ':
+    case '\t':
+    case '\r':
+      // line-ending backslash
+      // --- allow for extra whitespace chars after backslash
+      // --- skip until newline
+      p++;                     // skip the escape char
+      p += strspn(p, " \t\r"); // skip whitespaces
+      if (*p != '\n') {
+        return SETERROR(pp->ebuf, tok.lineno,
+                        "unexpected char after line-ending backslash");
+      }
+      // fallthru
+    case '\n':
+      // skip all whitespaces including newline
+      p++;
+      p += strspn(p, " \t\r\n");
+      continue;
+    default:
+      return SETERROR(pp->ebuf, tok.lineno,
+                      "internal: unknown escape char \\%c", p[1]);
+    }
+  }
+  *dst = 0;
+  ret_span->len = dst - ret_span->ptr;
+  return 0;
+}
+
+// ===================================================================
+// ==    SCANNER SECTION
+// ===================================================================
+
+// Get the next char
+static int scan_get(scanner_t *sp) {
+  int ret = TOK_FIN;
+  const char *p = sp->cur;
+  if (p < sp->endp) {
+    ret = *p++;
+    if (ret == '\r' && p < sp->endp && *p == '\n') {
+      ret = *p++;
+    }
+  }
+  sp->cur = p;
+  if (ret == '\n') {
+    sp->lineno += 1;
+    sp->line_start = p;
+  }
+  return ret;
+}
+
+// Check if the next char matches ch.
+static inline bool scan_match(scanner_t *sp, int ch) {
+  const char *p = sp->cur;
+  // exact match? done.
+  if (p < sp->endp && *p == ch) {
+    return true;
+  }
+  // \n also matches \r\n
+  if (ch == '\n' && p + 1 < sp->endp) {
+    return p[0] == '\r' && p[1] == '\n';
+  }
+  // not a match
+  return false;
+}
+
+// Check if the next char is in accept[].
+static bool scan_matchany(scanner_t *sp, const char *accept) {
+  for (; *accept; accept++) {
+    if (scan_match(sp, *accept)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check if the next n chars match ch.
+static inline bool scan_nmatch(scanner_t *sp, int ch, int n) {
+  assert(ch != '\n'); // not handled
+  if (sp->cur + n > sp->endp) {
+    return false;
+  }
+  const char *p = sp->cur;
+  int i;
+  for (i = 0; i < n && p[i] == ch; i++)
+    ;
+  return i == n;
+}
+
+// Initialize a token.
+static inline token_t mktoken(scanner_t *sp, toktyp_t typ) {
+  token_t tok = {0};
+  tok.toktyp = typ;
+  tok.str.ptr = sp->cur;
+  tok.lineno = sp->lineno;
+  tok.colno = (int)(sp->cur - sp->line_start) + 1;
+  return tok;
+}
+
+#define S_GET() scan_get(sp)
+#define S_MATCH(ch) scan_match(sp, (ch))
+#define S_MATCH3(ch) scan_nmatch(sp, (ch), 3)
+#define S_MATCH4(ch) scan_nmatch(sp, (ch), 4)
+#define S_MATCH6(ch) scan_nmatch(sp, (ch), 6)
+
+static inline bool is_valid_char(int ch) {
+  // i.e. (0x20 <= ch && ch <= 0x7e) || (ch & 0x80);
+  return isprint(ch) || (ch & 0x80);
+}
+
+static inline bool is_hex_char(int ch) {
+  ch = toupper(ch);
+  return ('0' <= ch && ch <= '9') || ('A' <= ch && ch <= 'F');
+}
+
+// Initialize a scanner
+static void scan_init(scanner_t *sp, const char *src, int len, char *errbuf,
+                      int errbufsz) {
+  memset(sp, 0, sizeof(*sp));
+  sp->src = src;
+  sp->endp = src + len;
+  assert(*sp->endp == '\0');
+  sp->cur = src;
+  sp->lineno = 1;
+  sp->line_start = src;
+  sp->ebuf.ptr = errbuf;
+  sp->ebuf.len = errbufsz;
+}
+
+// Scan """ ... """
+static int scan_multiline_string(scanner_t *sp, token_t *tok) {
+  assert(S_MATCH3('"'));
+  S_GET(), S_GET(), S_GET(); // skip opening """
+
+  // According to spec: trim first newline after """
+  if (S_MATCH('\n')) {
+    S_GET();
+  }
+
+  *tok = mktoken(sp, TOK_MLSTRING);
+  // scan until terminating """
+  const char *escp = NULL;
+  while (1) {
+    if (S_MATCH3('"')) {
+      if (S_MATCH4('"')) {
+        // special case... """abcd """" -> (abcd ")
+        // but sequences of 3 or more double quotes are not allowed
+        if (S_MATCH6('"')) {
+          return SETERROR(sp->ebuf, sp->lineno,
+                          "detected sequences of 3 or more double quotes");
+        } else {
+          ; // no problem
+        }
+      } else {
+        break; // found terminating """
+      }
+    }
+    int ch = S_GET();
+    if (ch == TOK_FIN) {
+      return SETERROR(sp->ebuf, sp->lineno, "unterminated \"\"\"");
+    }
+    // If non-escaped char ...
+    if (ch != '\\') {
+      if (!(is_valid_char(ch) || (ch && strchr(" \t\n", ch)))) {
+        return SETERROR(sp->ebuf, sp->lineno, "invalid char in string");
+      }
+      continue;
+    }
+    // ch is backslash
+    if (!escp) {
+      escp = sp->cur - 1;
+      assert(*escp == '\\');
+    }
+
+    // handle escape char
+    ch = S_GET();
+    if (ch && strchr("btnfre\"\\", ch)) {
+      // skip \", \\, \b, \f, \n, \r, \t
+      continue;
+    }
+    int top = 0;
+    switch (ch) {
+    case 'x':
+      top = 2;
+      break;
+    case 'u':
+      top = 4;
+      break;
+    case 'U':
+      top = 8;
+      break;
+    default:
+      break;
+    }
+    if (top) {
+      for (int i = 0; i < top; i++) {
+        if (!is_hex_char(S_GET())) {
+          return SETERROR(sp->ebuf, sp->lineno,
+                          "expect %d hex digits after \\%c", top, ch);
+        }
+      }
+      continue;
+    }
+    // handle line-ending backslash
+    if (ch == ' ' || ch == '\t') {
+      // Although the spec does not allow for whitespace following a
+      // line-ending backslash, some standard tests expect it.
+      // Skip whitespace till EOL.
+      while (ch != TOK_FIN && ch && strchr(" \t", ch)) {
+        ch = S_GET();
+      }
+      if (ch != '\n') {
+        // Got a backslash followed by whitespace, followed by some char
+        // before newline
+        return SETERROR(sp->ebuf, sp->lineno, "bad escape char in string");
+      }
+      // fallthru
+    }
+    if (ch == '\n') {
+      // got a line-ending backslash
+      // - skip all whitespaces
+      while (scan_matchany(sp, " \t\n")) {
+        S_GET();
+      }
+      continue;
+    }
+    return SETERROR(sp->ebuf, sp->lineno, "bad escape char in string");
+  }
+  tok->str.len = sp->cur - tok->str.ptr;
+  tok->u.escp = escp;
+
+  assert(S_MATCH3('"'));
+  S_GET(), S_GET(), S_GET();
+  return 0;
+}
+
+// Scan " ... "
+static int scan_string(scanner_t *sp, token_t *tok) {
+  assert(S_MATCH('"'));
+  if (S_MATCH3('"')) {
+    return scan_multiline_string(sp, tok);
+  }
+  S_GET(); // skip opening "
+
+  // scan until closing "
+  *tok = mktoken(sp, TOK_STRING);
+  const char *escp = NULL;
+  while (!S_MATCH('"')) {
+    int ch = S_GET();
+    if (ch == TOK_FIN) {
+      return SETERROR(sp->ebuf, sp->lineno, "unterminated string");
+    }
+    // If non-escaped char ...
+    if (ch != '\\') {
+      if (!(is_valid_char(ch) || ch == ' ' || ch == '\t')) {
+        return SETERROR(sp->ebuf, sp->lineno, "invalid char in string");
+      }
+      continue;
+    }
+    // ch is backslash
+    if (!escp) {
+      escp = sp->cur - 1;
+      assert(*escp == '\\');
+    }
+
+    // handle escape char
+    ch = S_GET();
+    if (ch && strchr("btnfre\"\\", ch)) {
+      // skip \b, \t, \n, \f, \r, \e, \", \\  .
+      continue;
+    }
+    int top = 0;
+    switch (ch) {
+    case 'x':
+      top = 2;
+      break;
+    case 'u':
+      top = 4;
+      break;
+    case 'U':
+      top = 8;
+      break;
+    default:
+      return SETERROR(sp->ebuf, sp->lineno, "bad escape char in string");
+    }
+    for (int i = 0; i < top; i++) {
+      if (!is_hex_char(S_GET())) {
+        return SETERROR(sp->ebuf, sp->lineno, "expect %d hex digits after \\%c",
+                        top, ch);
+      }
+    }
+  }
+  tok->str.len = sp->cur - tok->str.ptr;
+  tok->u.escp = escp;
+
+  assert(S_MATCH('"'));
+  S_GET(); // skip the terminating "
+  return 0;
+}
+
+// Scan ''' ... '''
+static int scan_multiline_litstring(scanner_t *sp, token_t *tok) {
+  assert(S_MATCH3('\''));
+  S_GET(), S_GET(), S_GET(); // skip opening '''
+
+  // According to spec: trim first newline after '''
+  if (S_MATCH('\n')) {
+    S_GET();
+  }
+
+  // scan until terminating '''
+  *tok = mktoken(sp, TOK_MLLITSTRING);
+  while (1) {
+    if (S_MATCH3('\'')) {
+      if (S_MATCH4('\'')) {
+        // special case... '''abcd '''' -> (abcd ')
+        // but sequences of 3 or more single quotes are not allowed
+        if (S_MATCH6('\'')) {
+          return SETERROR(sp->ebuf, sp->lineno,
+                          "sequences of 3 or more single quotes");
+        } else {
+          ; // no problem
+        }
+      } else {
+        break; // found terminating '''
+      }
+    }
+    int ch = S_GET();
+    if (ch == TOK_FIN) {
+      return SETERROR(sp->ebuf, sp->lineno,
+                      "unterminated multiline lit string");
+    }
+    if (!(is_valid_char(ch) || (ch && strchr(" \t\n", ch)))) {
+      return SETERROR(sp->ebuf, sp->lineno, "invalid char in string");
+    }
+  }
+  tok->str.len = sp->cur - tok->str.ptr;
+
+  assert(S_MATCH3('\''));
+  S_GET(), S_GET(), S_GET();
+  return 0;
+}
+
+// Scan ' ... '
+static int scan_litstring(scanner_t *sp, token_t *tok) {
+  assert(S_MATCH('\''));
+  if (S_MATCH3('\'')) {
+    return scan_multiline_litstring(sp, tok);
+  }
+  S_GET(); // skip opening '
+
+  // scan until closing '
+  *tok = mktoken(sp, TOK_LITSTRING);
+  while (!S_MATCH('\'')) {
+    int ch = S_GET();
+    if (ch == TOK_FIN) {
+      return SETERROR(sp->ebuf, sp->lineno, "unterminated string");
+    }
+    if (!(is_valid_char(ch) || ch == '\t')) {
+      return SETERROR(sp->ebuf, sp->lineno, "invalid char in string");
+    }
+  }
+  tok->str.len = sp->cur - tok->str.ptr;
+  assert(S_MATCH('\''));
+  S_GET();
+  return 0;
+}
+
+static bool is_valid_date(int year, int month, int day) {
+  if (!(1 <= year)) {
+    return false;
+  }
+  if (!(1 <= month && month <= 12)) {
+    return false;
+  }
+  int is_leap_year = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+  int days_in_month[] = {
+      31, 28 + is_leap_year, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+  return (1 <= day && day <= days_in_month[month - 1]);
+}
+
+static bool is_valid_time(int hour, int minute, int sec, int usec) {
+  if (!(0 <= hour && hour <= 23)) {
+    return false;
+  }
+  if (!(0 <= minute && minute <= 59)) {
+    return false;
+  }
+  if (!(0 <= sec && sec <= 59)) {
+    return false;
+  }
+  if (!(0 <= usec)) {
+    return false;
+  }
+  return true;
+}
+
+static bool is_valid_timezone(int minute) {
+  minute = (minute < 0 ? -minute : minute);
+  int hour = minute / 60;
+  minute = minute % 60;
+  if (!(0 <= hour && hour <= 23)) {
+    return false;
+  }
+  if (!(0 <= minute && minute < 60)) {
+    return false;
+  }
+  return true;
+}
+
+// Read an int (without signs) from the string p.
+static int read_int(const char *p, int *ret) {
+  const char *pp = p;
+  int64_t val = 0;
+  for (; isdigit(*p); p++) {
+    val = val * 10 + (*p - '0');
+    if (val > INT_MAX) {
+      return 0; // overflowed
+    }
+  }
+  *ret = (int)val;
+  return p - pp;
+}
+
+// Read a date as YYYY-MM-DD from p[]. Return #bytes consumed.
+static int read_date(const char *p, int *year, int *month, int *day) {
+  const char *pp = p;
+  int n;
+  n = read_int(p, year);
+  if (n != 4 || p[4] != '-') {
+    return 0;
+  }
+  n = read_int(p += n + 1, month);
+  if (n != 2 || p[2] != '-') {
+    return 0;
+  }
+  n = read_int(p += n + 1, day);
+  if (n != 2) {
+    return 0;
+  }
+  p += 2;
+  assert(p - pp == 10);
+  return p - pp;
+}
+
+// Read a time as HH:MM:SS.subsec from p[]. Return #bytes consumed.
+static int read_time(const char *p, int *hour, int *minute, int *second,
+                     int *usec) {
+  const char *pp = p;
+  int n;
+  *hour = *minute = *second = *usec = 0;
+  // scan hours
+  n = read_int(p, hour);
+  if (n != 2 || p[2] != ':') {
+    return 0;
+  }
+  p += 3;
+
+  // scan minutes
+  n = read_int(p, minute);
+  if (n != 2) {
+    return 0;
+  }
+  if (p[2] != ':') {
+    // seconds are optional in v1.1
+    p += 2;
+    return p - pp;
+  }
+  p += 3;
+
+  // scan seconds
+  n = read_int(p, second);
+  if (n != 2) {
+    return 0;
+  }
+  p += 2;
+
+  if (*p != '.') {
+    return p - pp;
+  }
+  p++; // skip the period
+  if (!isdigit(*p)) {
+    // trailing period
+    return 0;
+  }
+  int micro_factor = 100000;
+  while (isdigit(*p) && micro_factor) {
+    *usec += (*p - '0') * micro_factor;
+    micro_factor /= 10;
+    p++;
+  }
+  while (isdigit(*p))
+    p++; // consume extra sub-microsecond digits
+  return p - pp;
+}
+
+// Reads a timezone from p[]. Return #bytes consumed.
+// tzhours and tzminutes restricted to 2-char integers only.
+static int read_tzone(const char *p, char *tzsign, int *tzhour, int *tzminute) {
+  const char *pp = p;
+
+  // Default values
+  *tzhour = *tzminute = 0;
+  *tzsign = '+';
+
+  // Look for Zulu
+  if (*p == 'Z' || *p == 'z') {
+    return 1; // done! tz is +00:00.
+  }
+
+  // Look for +/-
+  *tzsign = *p++;
+  if (!(*tzsign == '+' || *tzsign == '-')) {
+    return 0;
+  }
+
+  // Look for HH:MM
+  int n;
+  n = read_int(p, tzhour);
+  if (n != 2 || p[2] != ':') {
+    return 0;
+  }
+  n = read_int(p += 3, tzminute);
+  if (n != 2) {
+    return 0;
+  }
+  p += 2;
+  return p - pp;
+}
+
+// Scan hh:mm:ss.xxxxx
+static int scan_time(scanner_t *sp, token_t *tok) {
+  int lineno = sp->lineno;
+  char buffer[20];
+  scan_copystr(sp, buffer, sizeof(buffer));
+
+  char *p = buffer;
+  int hour, minute, sec, usec;
+  int len = read_time(p, &hour, &minute, &sec, &usec);
+  if (len == 0) {
+    return SETERROR(sp->ebuf, lineno, "invalid time");
+  }
+  if (!is_valid_time(hour, minute, sec, usec)) {
+    return SETERROR(sp->ebuf, lineno, "invalid time");
+  }
+
+  *tok = mktoken(sp, TOK_TIME);
+  tok->str.len = len;
+  sp->cur += len;
+  tok->u.tsval.year = -1;
+  tok->u.tsval.month = -1;
+  tok->u.tsval.day = -1;
+  tok->u.tsval.hour = hour;
+  tok->u.tsval.minute = minute;
+  tok->u.tsval.sec = sec;
+  tok->u.tsval.usec = usec;
+  tok->u.tsval.tz = -1;
+  return 0;
+}
+
+// Scan a time, a date, a datetime, or a datatimetz
+static int scan_timestamp(scanner_t *sp, token_t *tok) {
+  int year, month, day, hour, minute, sec, usec, tz;
+  year = month = day = hour = minute = sec = usec = tz = -1;
+
+  int n;
+  // make a copy of sp->cur into buffer to ensure NUL terminated string
+  char buffer[80];
+  scan_copystr(sp, buffer, sizeof(buffer));
+
+  toktyp_t toktyp = TOK_FIN;
+  int lineno = sp->lineno;
+
+  // See if this a TIME only
+  const char *p = buffer;
+  if (isdigit(p[0]) && isdigit(p[1]) && p[2] == ':') {
+    n = read_time(buffer, &hour, &minute, &sec, &usec);
+    if (!n) {
+      return SETERROR(sp->ebuf, lineno, "invalid time");
+    }
+    toktyp = TOK_TIME;
+    p += n;
+    goto done;
+  }
+
+  // Try reading a DATE
+  n = read_date(p, &year, &month, &day);
+  if (!n) {
+    return SETERROR(sp->ebuf, lineno, "invalid date");
+  }
+  toktyp = TOK_DATE;
+  p += n;
+
+  // Check if there is no time component in addition
+  if (!((p[0] == 'T' || p[0] == ' ' || p[0] == 't') && isdigit(p[1]) &&
+        isdigit(p[2]) && p[3] == ':')) {
+    goto done; // no TIME component. we are done.
+  }
+
+  // Read the TIME
+  n = read_time(p += 1, &hour, &minute, &sec, &usec);
+  if (!n) {
+    return SETERROR(sp->ebuf, lineno, "invalid timestamp");
+  }
+  toktyp = TOK_DATETIME;
+  p += n;
+
+  // Read the (optional) timezone
+  char tzsign;
+  int tzhour, tzminute;
+  n = read_tzone(p, &tzsign, &tzhour, &tzminute);
+  if (n == 0) {
+    goto done; // datetime only
+  }
+  toktyp = TOK_DATETIMETZ;
+  p += n;
+
+  // Check tzminute range. This must be done here instead of is_valid_timezone()
+  // because we combine tzhour and tzminute into tz (by minutes only).
+  if (!(0 <= tzminute && tzminute < 60)) {
+    return SETERROR(sp->ebuf, lineno, "invalid timezone");
+  }
+  tz = (tzhour * 60 + tzminute) * (tzsign == '-' ? -1 : 1);
+  goto done; // datetimetz
+
+done:
+  *tok = mktoken(sp, toktyp);
+  n = p - buffer;
+  tok->str.len = n;
+  sp->cur += n;
+
+  tok->u.tsval.year = year;
+  tok->u.tsval.month = month;
+  tok->u.tsval.day = day;
+  tok->u.tsval.hour = hour;
+  tok->u.tsval.minute = minute;
+  tok->u.tsval.sec = sec;
+  tok->u.tsval.usec = usec;
+  tok->u.tsval.tz = tz;
+
+  // Do some error checks based on type
+  switch (tok->toktyp) {
+  case TOK_TIME:
+    if (!is_valid_time(hour, minute, sec, usec)) {
+      return SETERROR(sp->ebuf, lineno, "invalid time");
+    }
+    break;
+  case TOK_DATE:
+    if (!is_valid_date(year, month, day)) {
+      return SETERROR(sp->ebuf, lineno, "invalid date");
+    }
+    break;
+  case TOK_DATETIME:
+  case TOK_DATETIMETZ:
+    if (!is_valid_date(year, month, day)) {
+      return SETERROR(sp->ebuf, lineno, "invalid date");
+    }
+    if (!is_valid_time(hour, minute, sec, usec)) {
+      return SETERROR(sp->ebuf, lineno, "invalid time");
+    }
+    if (tok->toktyp == TOK_DATETIMETZ && !is_valid_timezone(tz)) {
+      return SETERROR(sp->ebuf, lineno, "invalid timezone");
+    }
+    break;
+  default:
+    assert(0);
+    return SETERROR(sp->ebuf, lineno, "internal error");
+  }
+
+  return 0;
+}
+
+// Given a toml number (int and float) in buffer[]:
+//   1. squeeze out '_'
+//   2. check for syntax restrictions
+static int process_numstr(char *buffer, int base, const char **reason) {
+  // squeeze out _
+  char *q = strchr(buffer, '_');
+  if (q) {
+    for (int i = q - buffer; buffer[i]; i++) {
+      if (buffer[i] != '_') {
+        *q++ = buffer[i];
+        continue;
+      }
+      int left = (i == 0) ? 0 : buffer[i - 1];
+      int right = buffer[i + 1];
+      if (!isdigit(left) && !(base == 16 && is_hex_char(left))) {
+        *reason = "underscore only allowed between digits";
+        return -1;
+      }
+      if (!isdigit(right) && !(base == 16 && is_hex_char(right))) {
+        *reason = "underscore only allowed between digits";
+        return -1;
+      }
+    }
+    *q = 0;
+  }
+
+  // decimal points must be surrounded by digits. Also, convert to lowercase.
+  for (int i = 0; buffer[i]; i++) {
+    if (buffer[i] == '.') {
+      if (i == 0 || !isdigit(buffer[i - 1]) || !isdigit(buffer[i + 1])) {
+        *reason = "decimal point must be surrounded by digits";
+        return -1;
+      }
+    } else if ('A' <= buffer[i] && buffer[i] <= 'Z') {
+      buffer[i] = tolower(buffer[i]);
+    }
+  }
+
+  if (base == 10) {
+    // check for leading 0:  '+01' is an error!
+    q = buffer;
+    q += (*q == '+' || *q == '-') ? 1 : 0;
+    if (q[0] == '0' && isdigit(q[1])) {
+      *reason = "leading 0 in numbers";
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+static int scan_float(scanner_t *sp, token_t *tok) {
+  char buffer[50]; // need to accommodate "9_007_199_254_740_991.0"
+  scan_copystr(sp, buffer, sizeof(buffer));
+
+  int lineno = sp->lineno;
+  char *p = buffer;
+  p += (*p == '+' || *p == '-') ? 1 : 0;
+  if (0 == memcmp(p, "nan", 3) || (0 == memcmp(p, "inf", 3))) {
+    p += 3;
+  } else {
+    p += strspn(p, "_0123456789eE.+-");
+  }
+  int len = p - buffer;
+  buffer[len] = 0;
+
+  const char *reason;
+  if (process_numstr(buffer, 10, &reason)) {
+    return SETERROR(sp->ebuf, lineno, "%s", reason);
+  }
+
+  errno = 0;
+  char *q;
+  double fp64 = strtod(buffer, &q);
+  if (errno || *q || q == buffer) {
+    return SETERROR(sp->ebuf, lineno, "error parsing float");
+  }
+
+  *tok = mktoken(sp, TOK_FLOAT);
+  tok->u.fp64 = fp64;
+  tok->str.len = len;
+  sp->cur += len;
+  return 0;
+}
+
+static int scan_number(scanner_t *sp, token_t *tok) {
+  const char *reason;
+  char buffer[50]; // need to accommodate "9_007_199_254_740_991.0"
+  scan_copystr(sp, buffer, sizeof(buffer));
+
+  char *p = buffer;
+  int lineno = sp->lineno;
+  // process %0x, %0o or %0b integers
+  if (p[0] == '0') {
+    const char *span = 0;
+    int base = 0;
+    switch (p[1]) {
+    case 'x':
+      base = 16;
+      span = "_0123456789abcdefABCDEF";
+      break;
+    case 'o':
+      base = 8;
+      span = "_01234567";
+      break;
+    case 'b':
+      base = 2;
+      span = "_01";
+      break;
+    }
+    if (base) {
+      p += 2;
+      p += strspn(p, span);
+      int len = p - buffer;
+      buffer[len] = 0;
+
+      if (process_numstr(buffer + 2, base, &reason)) {
+        return SETERROR(sp->ebuf, lineno, "%s", reason);
+      }
+
+      // use strtoll to obtain the value
+      *tok = mktoken(sp, TOK_INTEGER);
+      char *q;
+      errno = 0;
+      tok->u.int64 = strtoll(buffer + 2, &q, base);
+      if (errno || *q || q == buffer + 2) {
+        return SETERROR(sp->ebuf, lineno, "error parsing integer");
+      }
+      tok->str.len = len;
+      sp->cur += len;
+      return 0;
+    }
+  }
+
+  // handle inf/nan
+  if (*p == '+' || *p == '-') {
+    p++;
+  }
+  if (*p == 'i' || *p == 'n') {
+    return scan_float(sp, tok);
+  }
+
+  // regular int or float
+  p = buffer;
+  p += strspn(p, "0123456789_+-.eE");
+  int len = p - buffer;
+  buffer[len] = 0;
+
+  if (process_numstr(buffer, 10, &reason)) {
+    return SETERROR(sp->ebuf, lineno, "%s", reason);
+  }
+
+  *tok = mktoken(sp, TOK_INTEGER);
+  char *q;
+  errno = 0;
+  tok->u.int64 = strtoll(buffer, &q, 10);
+  if (errno || *q || q == buffer) {
+    if (*q && strchr(".eE", *q)) {
+      return scan_float(sp, tok); // try to fit a float
+    }
+    return SETERROR(sp->ebuf, lineno, "error parsing integer");
+  }
+
+  tok->str.len = len;
+  sp->cur += len;
+  return 0;
+}
+
+static int scan_bool(scanner_t *sp, token_t *tok) {
+  char buffer[10];
+  scan_copystr(sp, buffer, sizeof(buffer));
+
+  int lineno = sp->lineno;
+  bool val = false;
+  const char *p = buffer;
+  if (0 == strncmp(p, "true", 4)) {
+    val = true;
+    p += 4;
+  } else if (0 == strncmp(p, "false", 5)) {
+    val = false;
+    p += 5;
+  } else {
+    return SETERROR(sp->ebuf, lineno, "invalid boolean value");
+  }
+  if (*p && !strchr("# \r\n\t,}]", *p)) {
+    return SETERROR(sp->ebuf, lineno, "invalid boolean value");
+  }
+
+  int len = p - buffer;
+  *tok = mktoken(sp, TOK_BOOL);
+  tok->u.b1 = val;
+  tok->str.len = len;
+  sp->cur += len;
+  return 0;
+}
+
+// Check if the next token may be TIME
+static inline bool test_time(const char *p, const char *endp) {
+  return &p[2] < endp && isdigit(p[0]) && isdigit(p[1]) && p[2] == ':';
+}
+
+// Check if the next token may be DATE
+static inline bool test_date(const char *p, const char *endp) {
+  return &p[4] < endp && isdigit(p[0]) && isdigit(p[1]) && isdigit(p[2]) &&
+         isdigit(p[3]) && p[4] == '-';
+}
+
+// Check if the next token may be BOOL
+static inline bool test_bool(const char *p, const char *endp) {
+  return &p[0] < endp && (*p == 't' || *p == 'f');
+}
+
+// Check if the next token may be NUMBER
+static bool test_number(const char *p, const char *endp) {
+  if (&p[0] < endp && *p && strchr("0123456789+-._", *p)) {
+    return true;
+  }
+  if (&p[2] < endp) {
+    if (0 == memcmp(p, "nan", 3) || 0 == memcmp(p, "inf", 3)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Scan a literal that is not a string
+static int scan_nonstring_literal(scanner_t *sp, token_t *tok) {
+  int lineno = sp->lineno;
+  if (test_time(sp->cur, sp->endp)) {
+    return scan_time(sp, tok);
+  }
+
+  if (test_date(sp->cur, sp->endp)) {
+    return scan_timestamp(sp, tok);
+  }
+
+  if (test_bool(sp->cur, sp->endp)) {
+    return scan_bool(sp, tok);
+  }
+
+  if (test_number(sp->cur, sp->endp)) {
+    return scan_number(sp, tok);
+  }
+  return SETERROR(sp->ebuf, lineno, "invalid value");
+}
+
+// Return true if Unicode codepoint is allowed in a TOML 1.1 bare key.
+// Ranges taken verbatim from the TOML 1.1 spec grammar for bare-key-char.
+static bool is_unicode_bare_key_char(uint32_t cp) {
+  if (cp == 0xB2 || cp == 0xB3 || cp == 0xB9)
+    return true;
+  if (0xBC <= cp && cp <= 0xBE)
+    return true;
+  if (0xC0 <= cp && cp <= 0xD6)
+    return true;
+  if (0xD8 <= cp && cp <= 0xF6)
+    return true;
+  if (0xF8 <= cp && cp <= 0x37D)
+    return true;
+  if (0x37F <= cp && cp <= 0x1FFF)
+    return true;
+  if (cp == 0x200C || cp == 0x200D)
+    return true;
+  if (0x203F <= cp && cp <= 0x2040)
+    return true;
+  if (0x2070 <= cp && cp <= 0x218F)
+    return true;
+  if (0x2460 <= cp && cp <= 0x24FF)
+    return true;
+  if (0x2C00 <= cp && cp <= 0x2FEF)
+    return true;
+  if (0x3001 <= cp && cp <= 0xD7FF)
+    return true;
+  if (0xF900 <= cp && cp <= 0xFDCF)
+    return true;
+  if (0xFDF0 <= cp && cp <= 0xFFFD)
+    return true;
+  if (0x10000 <= cp && cp <= 0xEFFFF)
+    return true;
+  return false;
+}
+
+// Scan a literal
+static int scan_literal(scanner_t *sp, token_t *tok) {
+  *tok = mktoken(sp, TOK_LIT);
+  const char *p = sp->cur;
+  while (p < sp->endp) {
+    if (isalnum((unsigned char)*p) || *p == '_' || *p == '-') {
+      p++;
+      continue;
+    }
+    if ((unsigned char)*p >= 0x80) {
+      uint32_t cp;
+      int n = utf8_to_ucs(p, sp->endp - p, &cp);
+      if (n > 0 && is_unicode_bare_key_char(cp)) {
+        p += n;
+        continue;
+      }
+    }
+    break;
+  }
+  tok->str.len = p - tok->str.ptr;
+  sp->cur = p;
+  return 0;
+}
+
+// Save the current state of the scanner
+static scanner_state_t scan_mark(scanner_t *sp) {
+  scanner_state_t mark;
+  mark.sp = sp;
+  mark.cur = sp->cur;
+  mark.lineno = sp->lineno;
+  mark.line_start = sp->line_start;
+  return mark;
+}
+
+// Restore the scanner state to a previously saved state
+static void scan_restore(scanner_t *sp, scanner_state_t mark) {
+  assert(mark.sp == sp);
+  sp->cur = mark.cur;
+  sp->lineno = mark.lineno;
+  sp->line_start = mark.line_start;
+}
+
+// Return the next token
+static int scan_next(scanner_t *sp, bool keymode, token_t *tok) {
+  static const toktyp_t map[128] = {
+      ['\n'] = TOK_ENDL, ['.'] = TOK_DOT,    ['='] = TOK_EQUAL,
+      [','] = TOK_COMMA, ['{'] = TOK_LBRACE, ['}'] = TOK_RBRACE};
+again:
+  *tok = mktoken(sp, TOK_FIN);
+
+  int ch = S_GET();
+  if (ch == TOK_FIN) {
+    return 0;
+  }
+
+  tok->str.len = 1;
+  if (0 <= ch && ch < 128 && map[ch]) {
+    // map simple char to token type and done
+    tok->toktyp = map[ch];
+    return 0;
+  }
+
+  // handle char that require logic
+  switch (ch) {
+  case ' ':
+  case '\t':
+    goto again; // skip whitespace
+
+  case '#':
+    // comment: skip until newline
+    while (!S_MATCH('\n')) {
+      ch = S_GET();
+      if (ch == TOK_FIN)
+        break;
+      if ((0 <= ch && ch <= 0x8) || (0x0a <= ch && ch <= 0x1f) ||
+          (ch == 0x7f)) {
+        return SETERROR(sp->ebuf, sp->lineno, "bad control char in comment");
+      }
+    }
+    goto again; // skip comment
+
+  case '[':
+    tok->toktyp = TOK_LBRACK;
+    if (keymode && S_MATCH('[')) {
+      S_GET();
+      tok->toktyp = TOK_LLBRACK;
+      tok->str.len = 2;
+    }
+    break;
+
+  case ']':
+    tok->toktyp = TOK_RBRACK;
+    if (keymode && S_MATCH(']')) {
+      S_GET();
+      tok->toktyp = TOK_RRBRACK;
+      tok->str.len = 2;
+    }
+    break;
+
+  case '"':
+    sp->cur--;
+    DO(scan_string(sp, tok));
+    break;
+
+  case '\'':
+    sp->cur--;
+    DO(scan_litstring(sp, tok));
+    break;
+
+  default:
+    sp->cur--;
+    DO(keymode ? scan_literal(sp, tok) : scan_nonstring_literal(sp, tok));
+    break;
+  }
+
+  return 0;
+}
+
+// Check for stack overflow due to excessive number of brackets or braces
+static int check_overflow(scanner_t *sp, token_t *tok) {
+  switch (tok->toktyp) {
+  case TOK_LBRACK:
+    sp->bracket_level++;
+    if (sp->bracket_level > BRACKET_LEVEL_MAX) {
+      return SETERROR(sp->ebuf, sp->lineno, "stack overflow");
+    }
+    break;
+  case TOK_RBRACK:
+    sp->bracket_level--;
+    break;
+  case TOK_LBRACE:
+    sp->brace_level++;
+    if (sp->brace_level > BRACE_LEVEL_MAX) {
+      return SETERROR(sp->ebuf, sp->lineno, "stack overflow");
+    }
+    break;
+  case TOK_RBRACE:
+    sp->brace_level--;
+    break;
+  default:
+    break;
+  }
+  return 0;
+}
+
+static int scan_key(scanner_t *sp, token_t *tok) {
+  if (sp->errmsg) {
+    return -1;
+  }
+  if (scan_next(sp, true, tok) || check_overflow(sp, tok)) {
+    sp->errmsg = sp->ebuf.ptr;
+    return -1;
+  }
+  return 0;
+}
+
+static int scan_value(scanner_t *sp, token_t *tok) {
+  if (sp->errmsg) {
+    return -1;
+  }
+  if (scan_next(sp, false, tok) || check_overflow(sp, tok)) {
+    sp->errmsg = sp->ebuf.ptr;
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * Convert a char in utf8 into UCS, and store it in *ret.
+ * Return #bytes consumed or -1 on failure.
+ */
+static int utf8_to_ucs(const char *orig, int len, uint32_t *ret) {
+  const unsigned char *buf = (const unsigned char *)orig;
+  unsigned i = *buf++;
+  uint32_t v;
+
+  /* 0x00000000 - 0x0000007F:
+     0xxxxxxx
+  */
+  if (0 == (i >> 7)) {
+    if (len < 1)
+      return -1;
+    v = i;
+    return *ret = v, 1;
+  }
+  /* 0x00000080 - 0x000007FF:
+     110xxxxx 10xxxxxx
+  */
+  if (0x6 == (i >> 5)) {
+    if (len < 2)
+      return -1;
+    v = i & 0x1f;
+    for (int j = 0; j < 1; j++) {
+      i = *buf++;
+      if (0x2 != (i >> 6))
+        return -1;
+      v = (v << 6) | (i & 0x3f);
+    }
+    return *ret = v, (const char *)buf - orig;
+  }
+
+  /* 0x00000800 - 0x0000FFFF:
+     1110xxxx 10xxxxxx 10xxxxxx
+  */
+  if (0xE == (i >> 4)) {
+    if (len < 3)
+      return -1;
+    v = i & 0x0F;
+    for (int j = 0; j < 2; j++) {
+      i = *buf++;
+      if (0x2 != (i >> 6))
+        return -1;
+      v = (v << 6) | (i & 0x3f);
+    }
+    return *ret = v, (const char *)buf - orig;
+  }
+
+  /* 0x00010000 - 0x001FFFFF:
+     11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+  */
+  if (0x1E == (i >> 3)) {
+    if (len < 4)
+      return -1;
+    v = i & 0x07;
+    for (int j = 0; j < 3; j++) {
+      i = *buf++;
+      if (0x2 != (i >> 6))
+        return -1;
+      v = (v << 6) | (i & 0x3f);
+    }
+    return *ret = v, (const char *)buf - orig;
+  }
+
+  if (0) {
+    // NOTE: these code points taking more than 4 bytes are not supported
+
+    /* 0x00200000 - 0x03FFFFFF:
+       111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (0x3E == (i >> 2)) {
+      if (len < 5)
+        return -1;
+      v = i & 0x03;
+      for (int j = 0; j < 4; j++) {
+        i = *buf++;
+        if (0x2 != (i >> 6))
+          return -1;
+        v = (v << 6) | (i & 0x3f);
+      }
+      return *ret = v, (const char *)buf - orig;
+    }
+
+    /* 0x04000000 - 0x7FFFFFFF:
+       1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (0x7e == (i >> 1)) {
+      if (len < 6)
+        return -1;
+      v = i & 0x01;
+      for (int j = 0; j < 5; j++) {
+        i = *buf++;
+        if (0x2 != (i >> 6))
+          return -1;
+        v = (v << 6) | (i & 0x3f);
+      }
+      return *ret = v, (const char *)buf - orig;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Convert a UCS char to utf8 code, and return it in buf.
+ * Return #bytes used in buf to encode the char, or
+ * -1 on error.
+ */
+static int ucs_to_utf8(uint32_t code, char buf[4]) {
+  /* http://stackoverflow.com/questions/6240055/manually-converting-unicode-codepoints-into-utf-8-and-utf-16
+   */
+  /* The UCS code values 0xd800–0xdfff (UTF-16 surrogates) as well
+   * as 0xfffe and 0xffff (UCS noncharacters) should not appear in
+   * conforming UTF-8 streams.
+   */
+  /*
+   *  https://github.com/toml-lang/toml-test/issues/165
+   *  [0xd800, 0xdfff] and [0xfffe, 0xffff] are implicitly allowed by TOML, so
+   * we disable the check.
+   */
+  if (0) {
+    if (0xd800 <= code && code <= 0xdfff)
+      return -1;
+    if (0xfffe <= code && code <= 0xffff)
+      return -1;
+  }
+
+  /* 0x00000000 - 0x0000007F:
+     0xxxxxxx
+  */
+  if (code <= 0x7F) {
+    buf[0] = (unsigned char)code;
+    return 1;
+  }
+
+  /* 0x00000080 - 0x000007FF:
+     110xxxxx 10xxxxxx
+  */
+  if (code <= 0x000007FF) {
+    buf[0] = (unsigned char)(0xc0 | (code >> 6));
+    buf[1] = (unsigned char)(0x80 | (code & 0x3f));
+    return 2;
+  }
+
+  /* 0x00000800 - 0x0000FFFF:
+     1110xxxx 10xxxxxx 10xxxxxx
+  */
+  if (code <= 0x0000FFFF) {
+    buf[0] = (unsigned char)(0xe0 | (code >> 12));
+    buf[1] = (unsigned char)(0x80 | ((code >> 6) & 0x3f));
+    buf[2] = (unsigned char)(0x80 | (code & 0x3f));
+    return 3;
+  }
+
+  /* 0x00010000 - 0x001FFFFF:
+     11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+  */
+  if (code <= 0x001FFFFF) {
+    buf[0] = (unsigned char)(0xf0 | (code >> 18));
+    buf[1] = (unsigned char)(0x80 | ((code >> 12) & 0x3f));
+    buf[2] = (unsigned char)(0x80 | ((code >> 6) & 0x3f));
+    buf[3] = (unsigned char)(0x80 | (code & 0x3f));
+    return 4;
+  }
+
+#ifdef UNDEF
+  if (0) {
+    // NOTE: these code points taking more than 4 bytes are not supported
+    /* 0x00200000 - 0x03FFFFFF:
+       111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x03FFFFFF) {
+      buf[0] = (unsigned char)(0xf8 | (code >> 24));
+      buf[1] = (unsigned char)(0x80 | ((code >> 18) & 0x3f));
+      buf[2] = (unsigned char)(0x80 | ((code >> 12) & 0x3f));
+      buf[3] = (unsigned char)(0x80 | ((code >> 6) & 0x3f));
+      buf[4] = (unsigned char)(0x80 | (code & 0x3f));
+      return 5;
+    }
+
+    /* 0x04000000 - 0x7FFFFFFF:
+       1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x7FFFFFFF) {
+      buf[0] = (unsigned char)(0xfc | (code >> 30));
+      buf[1] = (unsigned char)(0x80 | ((code >> 24) & 0x3f));
+      buf[2] = (unsigned char)(0x80 | ((code >> 18) & 0x3f));
+      buf[3] = (unsigned char)(0x80 | ((code >> 12) & 0x3f));
+      buf[4] = (unsigned char)(0x80 | ((code >> 6) & 0x3f));
+      buf[5] = (unsigned char)(0x80 | (code & 0x3f));
+      return 6;
+    }
+  }
+#endif
+
+  return -1;
+}

--- a/src/app/tomlc17/tomlc17.h
+++ b/src/app/tomlc17/tomlc17.h
@@ -1,0 +1,248 @@
+/* Copyright (c) 2024-2026, CK Tan.
+ * https://github.com/cktan/tomlc17/blob/main/LICENSE
+ */
+
+/**
+ * @file tomlc17.h
+ * @brief A TOML parser for C17.
+ *
+ * This library provides a simple and efficient way to parse TOML documents
+ * in C. It supports standard TOML features and provides an easy-to-use API
+ * for traversing the parsed data.
+ */
+
+#ifndef TOMLC17_H
+#define TOMLC17_H
+
+// A crude way to determine version. Manually changed.
+#define TOMLC17_RELEASE_AFTER "260517"
+
+/*
+ *  USAGE:
+ *
+ *  1. Call toml_parse(), toml_parse_file(), or toml_parse_file_ex()
+ *  2. Check result.ok
+ *  3. Use toml_get() or toml_seek() to query and traverse the
+ *     result.toptab
+ *  4. Call toml_free() to release resources.
+ *
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+#define TOML_EXTERN extern "C"
+#else
+#define TOML_EXTERN extern
+#endif
+
+/**
+ * @brief Enumeration of TOML data types.
+ */
+enum toml_type_t {
+  TOML_UNKNOWN = 0, /**< Unknown or invalid type */
+  TOML_STRING,      /**< String type */
+  TOML_INT64,       /**< 64-bit integer type */
+  TOML_FP64,        /**< 64-bit floating point type */
+  TOML_BOOLEAN,     /**< Boolean type */
+  TOML_DATE,        /**< Local date type */
+  TOML_TIME,        /**< Local time type */
+  TOML_DATETIME,    /**< Local datetime type */
+  TOML_DATETIMETZ,  /**< Offset datetime type */
+  TOML_ARRAY,       /**< Array type */
+  TOML_TABLE,       /**< Table type */
+};
+typedef enum toml_type_t toml_type_t;
+
+/**
+ * @brief Represents a single piece of TOML data.
+ *
+ * This structure is a node in a tree that represents a TOML document.
+ * The `u` union contains the actual value based on the `type` field.
+ */
+typedef struct toml_datum_t toml_datum_t;
+struct toml_datum_t {
+  toml_type_t type; /**< Type of the datum */
+  uint32_t flag;    /**< Internal flag, do not use */
+  int lineno;       /**< 1-based source line number, 0 if synthesized */
+  int colno;        /**< 1-based source column number, 0 if synthesized */
+  union {
+    const char *s; /**< Shorthand for str.ptr */
+    struct {
+      const char *ptr; /**< NUL terminated string pointer */
+      int len; /**< Length of the string excluding the terminating NUL */
+    } str;
+    int64_t int64; /**< 64-bit integer value */
+    double fp64;   /**< 64-bit floating point value */
+    bool boolean;  /**< Boolean value */
+    struct {       /**< Date and time components */
+      int16_t year, month, day;
+      int16_t hour, minute, second;
+      int32_t usec;
+      int16_t tz; /**< Timezone offset in minutes */
+    } ts;
+    struct {              /**< Array data */
+      int32_t size;       /**< Number of elements in the array */
+      toml_datum_t *elem; /**< Array of elements */
+    } arr;
+    struct {               /**< Table data */
+      int32_t size;        /**< Number of keys in the table */
+      const char **key;    /**< Array of keys */
+      int *len;            /**< Array of key lengths */
+      toml_datum_t *value; /**< Array of values corresponding to keys */
+    } tab;
+  } u;
+};
+
+/**
+ * @brief Result of a TOML parsing operation.
+ */
+typedef struct toml_result_t toml_result_t;
+struct toml_result_t {
+  bool ok;             /**< True if parsing was successful */
+  toml_datum_t toptab; /**< The top-level table (valid if ok is true) */
+  char errmsg[200];    /**< Error message (valid if ok is false) */
+  void *__internal;    /**< Internal state, do not use */
+};
+
+/**
+ * @brief Parse a TOML document from a string.
+ *
+ * @param src A NUL-terminated string containing the TOML document.
+ * @param len The length of the string (excluding the NUL terminator).
+ * @return A toml_result_t structure. Must be freed with toml_free().
+ *
+ * IMPORTANT: src[] must be a NUL terminated string! The len parameter
+ * does not include the NUL terminator.
+ */
+TOML_EXTERN toml_result_t toml_parse(const char *src, int len);
+
+/**
+ * @brief Parse a TOML document from a file pointer.
+ *
+ * @param fp A pointer to the open file. The caller is responsible for closing
+ * it.
+ * @return A toml_result_t structure. Must be freed with toml_free().
+ *
+ * IMPORTANT: you are still responsible to fclose(fp).
+ */
+TOML_EXTERN toml_result_t toml_parse_file(FILE *fp);
+
+/**
+ * @brief Parse a TOML document from a file path.
+ *
+ * @param fname The path to the TOML file.
+ * @return A toml_result_t structure. Must be freed with toml_free().
+ */
+TOML_EXTERN toml_result_t toml_parse_file_ex(const char *fname);
+
+/**
+ * @brief Release resources allocated for a TOML result.
+ *
+ * @param result The TOML result to free.
+ */
+TOML_EXTERN void toml_free(toml_result_t result);
+
+/**
+ * @brief Find a value for a specific key in a TOML table.
+ *
+ * @param table The TOML table to search in.
+ * @param key The key to look for.
+ * @return The value associated with the key, or a datum with type TOML_UNKNOWN
+ * if not found.
+ */
+TOML_EXTERN toml_datum_t toml_get(toml_datum_t table, const char *key);
+
+/**
+ * @brief Locate a value using a multipart-key (e.g., "a.b.c").
+ *
+ * @param table The TOML table to start the search from.
+ * @param multipart_key A dot-separated key string. No escape characters
+ * allowed. Maximum length is 255 bytes.
+ * @return The value found, or a datum with type TOML_UNKNOWN if not found.
+ */
+TOML_EXTERN toml_datum_t toml_seek(toml_datum_t table,
+                                   const char *multipart_key);
+
+/**
+ * @brief OBSOLETE: use toml_get() instead.
+ * Find a key in a toml_table. Return the value of the key if found,
+ * or a TOML_UNKNOWN otherwise.
+ */
+static inline toml_datum_t toml_table_find(toml_datum_t table,
+                                           const char *key) {
+  return toml_get(table, key);
+}
+
+/**
+ * @brief Merge two TOML results.
+ *
+ * All results (r1, r2, and the returned result) must be freed independently.
+ *
+ * @param r1 The base TOML result.
+ * @param r2 The TOML result containing overrides.
+ * @return A new toml_result_t representing the merged document.
+ *
+ *  LOGIC:
+ *   ret = copy of r1
+ *   for each item x in r2:
+ *     if x is not in ret:
+ *         set x in ret
+ *     elif x in ret is NOT of the same type:
+ *         override
+ *     elif x in ret is an array of tables:
+ *         append r2.x to ret.x
+ *     elif x in ret is a table:
+ *         merge r2.x to ret.x
+ *     else:
+ *         override
+ */
+TOML_EXTERN toml_result_t toml_merge(const toml_result_t *r1,
+                                     const toml_result_t *r2);
+
+/**
+ * @brief Compare two TOML results for equality.
+ *
+ * Comparison is sensitive to the order of elements in arrays and tables.
+ *
+ * @param r1 The first TOML result.
+ * @param r2 The second TOML result.
+ * @return True if they are equivalent, false otherwise.
+ */
+TOML_EXTERN bool toml_equiv(const toml_result_t *r1, const toml_result_t *r2);
+
+/**
+ * @brief Global options for the TOML parser.
+ */
+typedef struct toml_option_t toml_option_t;
+struct toml_option_t {
+  bool check_utf8; /**< If true, check if all characters are valid UTF-8.
+                      Default: false. */
+  void *(*mem_realloc)(
+      void *ptr,
+      size_t size); /**< Custom realloc function. Default: realloc(). */
+  void (*mem_free)(void *ptr); /**< Custom free function. Default: free(). */
+};
+
+/**
+ * @brief Get the default parser options.
+ *
+ * Use this to obtain and initialize a toml_option_t structure before
+ * customizing it.
+ *
+ * @return A toml_option_t with default values.
+ */
+TOML_EXTERN toml_option_t toml_default_option(void);
+
+/**
+ * @brief Set the global parser options.
+ *
+ * Call this only if you need to override the default behavior.
+ *
+ * @param opt The options to set.
+ */
+TOML_EXTERN void toml_set_option(toml_option_t opt);
+
+#endif // TOMLC17_H

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -40,7 +40,12 @@ static void unset_env_var(const char *key) {
 
 static void clear_test_env(void) {
     const char *keys[] = {
-        "mode", "output_file", "font_size", "invert", "sdl_vsync", "char_size", "refresh"
+        "show_help", "show_aahelp", "show_version",
+        "quiet", "mode", "device", "input", "size", "pixel_size", "char_size",
+        "output_file", "aa_driver", "daemon", "font_size", "font_face",
+        "refresh", "aa_bright", "aa_contrast", "aa_gamma", "invert",
+        "background", "foreground", "uid", "gid", "frames",
+        "sdl_renderer", "sdl_vsync", "fullscreen", "mirror"
     };
     size_t i;
     for (i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
@@ -146,11 +151,60 @@ static void test_toml_unknown_key(void) {
     remove(path);
 }
 
+static void test_toml_mirror_roundtrip(void) {
+    hasciicam_config cfg;
+    hasciicam_config loaded;
+    char err[200];
+    const char *path = "test_app_config_mirror.toml";
+
+    hasciicam_config_init_defaults(&cfg);
+    cfg.mirror_x = 0;
+    cfg.mirror_y = 1;
+    expect_true(hasciicam_config_save_toml(&cfg, path, err, sizeof(err)), "save_toml mirror should succeed");
+
+    hasciicam_config_init_defaults(&loaded);
+    expect_true(hasciicam_config_load_toml(&loaded, path, err, sizeof(err)), "load_toml mirror should succeed");
+    expect_true(loaded.mirror_x == 0, "mirror_x should roundtrip");
+    expect_true(loaded.mirror_y == 1, "mirror_y should roundtrip");
+    remove(path);
+}
+
+static void test_toml_size_key_rejected(void) {
+    hasciicam_config cfg;
+    char err[200];
+    const char *path = "test_app_config_size_alias.toml";
+    FILE *fp = fopen(path, "wb");
+    expect_true(fp != NULL, "should open size alias toml");
+    if (fp) {
+        fputs("size = \"80x25\"\n", fp);
+        fclose(fp);
+    }
+
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(!hasciicam_config_load_toml(&cfg, path, err, sizeof(err)), "load_toml should reject size alias");
+    remove(path);
+}
+
+static void test_env_size_key_ignored(void) {
+    hasciicam_config cfg;
+    char err[200];
+
+    clear_test_env();
+    set_env_var("size", "80x25");
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(hasciicam_config_load_env(&cfg, err, sizeof(err)), "load_env should ignore size alias");
+    expect_true(cfg.explicit_size == 0, "size alias should not set explicit size");
+    clear_test_env();
+}
+
 int main(void) {
     test_env_load();
     test_cli_overrides_env();
     test_toml_roundtrip();
     test_toml_unknown_key();
+    test_toml_mirror_roundtrip();
+    test_toml_size_key_rejected();
+    test_env_size_key_ignored();
 
     if (failures) {
         fprintf(stderr, "%d test(s) failed\n", failures);

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -1,0 +1,160 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/app/app_config.h"
+#include "../src/compat/getopt.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+static int failures = 0;
+
+static void expect_true(int cond, const char *msg) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        failures++;
+    }
+}
+
+static void set_env_var(const char *key, const char *value) {
+#if defined(_WIN32)
+    _putenv_s(key, value ? value : "");
+#else
+    if (value == NULL) {
+        unsetenv(key);
+    } else {
+        setenv(key, value, 1);
+    }
+#endif
+}
+
+static void unset_env_var(const char *key) {
+#if defined(_WIN32)
+    _putenv_s(key, "");
+#else
+    unsetenv(key);
+#endif
+}
+
+static void clear_test_env(void) {
+    const char *keys[] = {
+        "mode", "output_file", "font_size", "invert", "sdl_vsync", "char_size", "refresh"
+    };
+    size_t i;
+    for (i = 0; i < sizeof(keys) / sizeof(keys[0]); ++i) {
+        unset_env_var(keys[i]);
+    }
+}
+
+static void test_env_load(void) {
+    hasciicam_config cfg;
+    char err[200];
+
+    clear_test_env();
+    set_env_var("mode", "html");
+    set_env_var("output_file", "env.html");
+    set_env_var("font_size", "3");
+    set_env_var("invert", "true");
+    set_env_var("sdl_vsync", "off");
+    set_env_var("char_size", "80x25");
+
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(hasciicam_config_load_env(&cfg, err, sizeof(err)), "load_env should succeed");
+    expect_true(cfg.mode == 1, "mode should be html");
+    expect_true(strcmp(cfg.aafile, "env.html") == 0, "output_file should be env.html");
+    expect_true(cfg.fontsize == 3, "font_size should be 3");
+    expect_true(cfg.invert == 1, "invert should be true");
+    expect_true(cfg.sdl_vsync == 0, "sdl_vsync should be off");
+    expect_true(cfg.size_intent == HASCIICAM_SIZE_CHARS, "char_size should set char intent");
+    expect_true(cfg.size_w == 80 && cfg.size_h == 25, "char_size should parse 80x25");
+
+    clear_test_env();
+}
+
+static void test_cli_overrides_env(void) {
+    hasciicam_config cfg;
+    char *argv[] = {
+        (char *)"hasciicam",
+        (char *)"--mode", (char *)"text",
+        (char *)"--font-size", (char *)"2",
+        (char *)"-o", (char *)"cli.html"
+    };
+    int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+
+    clear_test_env();
+    set_env_var("mode", "html");
+    set_env_var("font_size", "4");
+    set_env_var("output_file", "env.html");
+
+    hasciicam_config_init_defaults(&cfg);
+    optind = 1;
+    hasciicam_config_parse(&cfg, argc, argv, "aahelp", "pkg", "1.0");
+
+    expect_true(cfg.mode == 2, "cli mode should override env mode");
+    expect_true(cfg.fontsize == 2, "cli font_size should override env font_size");
+    expect_true(strcmp(cfg.aafile, "cli.html") == 0, "cli output_file should override env output_file");
+
+    clear_test_env();
+}
+
+static void test_toml_roundtrip(void) {
+    hasciicam_config cfg;
+    hasciicam_config loaded;
+    char err[200];
+    const char *path = "test_app_config_roundtrip.toml";
+
+    hasciicam_config_init_defaults(&cfg);
+    cfg.mode = 2;
+    cfg.explicit_output = 1;
+    strcpy(cfg.aafile, "roundtrip.asc");
+    cfg.sdl_vsync = 1;
+    cfg.invert = 1;
+    cfg.size_intent = HASCIICAM_SIZE_CHARS;
+    cfg.size_w = 90;
+    cfg.size_h = 30;
+    cfg.explicit_size = 1;
+
+    expect_true(hasciicam_config_save_toml(&cfg, path, err, sizeof(err)), "save_toml should succeed");
+
+    hasciicam_config_init_defaults(&loaded);
+    expect_true(hasciicam_config_load_toml(&loaded, path, err, sizeof(err)), "load_toml should succeed");
+    expect_true(loaded.mode == 2, "roundtrip mode should be text");
+    expect_true(strcmp(loaded.aafile, "roundtrip.asc") == 0, "roundtrip output_file should match");
+    expect_true(loaded.sdl_vsync == 1, "roundtrip sdl_vsync should be on");
+    expect_true(loaded.invert == 1, "roundtrip invert should match");
+    expect_true(loaded.size_intent == HASCIICAM_SIZE_CHARS, "roundtrip size intent should be chars");
+    expect_true(loaded.size_w == 90 && loaded.size_h == 30, "roundtrip size should match");
+
+    remove(path);
+}
+
+static void test_toml_unknown_key(void) {
+    hasciicam_config cfg;
+    char err[200];
+    const char *path = "test_app_config_bad.toml";
+    FILE *fp = fopen(path, "wb");
+    expect_true(fp != NULL, "should open bad toml file");
+    if (fp) {
+        fputs("unknown_key = 1\n", fp);
+        fclose(fp);
+    }
+
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(!hasciicam_config_load_toml(&cfg, path, err, sizeof(err)), "load_toml should reject unknown key");
+    remove(path);
+}
+
+int main(void) {
+    test_env_load();
+    test_cli_overrides_env();
+    test_toml_roundtrip();
+    test_toml_unknown_key();
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add canonical config variable handling in `src/app/app_config.*`
- load launch config from lowercase environment keys, then apply CLI overrides
- add internal TOML load/save APIs and wire parser support through vendored `cktan/tomlc17`
- add focused config unit tests (`test_app_config`) and CMake integration
- document env keys and TOML usage in `doc/hasciicam.1` and `AGENTS.md`

## Details
- New internal APIs:
  - `hasciicam_config_load_env(...)`
  - `hasciicam_config_load_toml(...)`
  - `hasciicam_config_save_toml(...)`
- Preserved existing CLI spellings and behavior (`--aafile`, `--aadriver`, `-h`, `-H`, `-v`, size semantics)
- Added vendored parser files in `src/app/tomlc17/` with license and provenance note

## Verification
- `cmake --build build` (run from MSVC vcvars environment)
- `ctest --output-on-failure --test-dir build`
- `ctest --output-on-failure --test-dir build -R app_config`
- `ctest --output-on-failure --test-dir build -L cli`
- `build/hasciicam.exe -h`
- `build/hasciicam.exe -H`

## Commits
- `3af0cc5` feat(config): add env and toml-backed app config
- `c3aef70` docs(config): document env keys and toml config usage