### PR TITLE
feat: add AA font selection via CLI/config and live SDL GUI

### DIFF
--- a/.gestalt/plans/font-selection.org
+++ b/.gestalt/plans/font-selection.org
@@ -1,0 +1,152 @@
+#+TITLE: Font Selection
+#+SUBTITLE: Expose AA-lib font selection through CLI, TOML/env config, and SDL live GUI without unsafe live resizing
+#+DATE: 2026-06-01
+#+KEYWORDS: font aalib cli config gui sdl resize live
+
+* WIP [#A] Define a small AA font catalog API
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Provide one tested C API for listing, looking up, and describing bundled AA-lib fonts without exposing callers to direct `aa_fonts[]` iteration.
+:Notes: Challenge the first idea of having CLI, config, GUI, and SDL each iterate `aa_fonts[]` directly. That repeats lookup rules and makes `--font list` formatting drift from the GUI labels. Use a tiny adapter over existing AA-lib data instead. Do not add a dependency.
+:END:
+
+** DONE [#A] Add font lookup/list helpers
+:PROPERTIES:
+:Why: CLI parsing, TOML/env parsing, GUI combo boxes, and live SDL switching all need the same list of valid fonts.
+:Change: Add a small module, likely `src/render/render_font.h` and `src/render/render_font.c`, or `src/app/app_font.*` if it fits better after inspecting ownership. Implement helpers around AA-lib's existing `aa_fonts[]`: `hasciicam_font_count()`, `hasciicam_font_at(index)`, `hasciicam_font_find(name_or_shortname)`, and `hasciicam_font_default()`. The descriptor should expose short name, long name, height, and `const struct aa_font *font`. Match AA-lib's existing lookup semantics: accept either `font->shortname` or `font->name`, but store and persist the short name. Keep optional `vyhen` naturally included only if AA-lib registers it.
+:Tests: Add a plain C unit test that asserts the default build sees at least the known bundled fonts, can find `vga16`, can find the long name `"Standard vga 8x16 font"`, rejects an unknown name, and returns stable short names.
+:Done when: All code that needs a font can use one helper API, and tests prove lookup behavior without opening SDL or a camera.
+:END:
+
+** TODO [#A] Decide the canonical default font
+:PROPERTIES:
+:Why: The current default is implicit: AA-lib/SDL fall back to `aa_font16`, but config and GUI need an explicit value to show.
+:Change: Define the default font short name as `vga16` in the new font API. Keep behavior unchanged when no font is configured. During render session initialization, keep `hwparams.font = NULL` unless a configured font is selected; this preserves driver defaults. When exposing the current value to config/GUI, report `vga16` if the context or hardware params have no explicit font and SDL would use its fallback.
+:Tests: Unit test that the default helper returns `vga16`. Existing smoke tests must still render with no `--font` option.
+:Done when: The UI and saved TOML have a stable default name while runtime rendering remains backward-compatible.
+:END:
+
+** TODO [#B] Add a font listing formatter
+:PROPERTIES:
+:Why: `--font list` should be deterministic, readable, and reusable in tests without duplicating print code in the parser.
+:Change: Add a helper that writes all fonts to a `FILE *`, one font per line, with the short name first. Suggested format: `vga16\tStandard vga 8x16 font\t8x16`. Width is always 8 for these AA-lib bitmap fonts; height comes from `font->height`. Do not promise that all future fonts are width 8 unless the AA-lib `aa_font` structure remains width-less.
+:Tests: Unit test the formatter through a temporary file or direct helper if practical. At minimum, add a CLI test for `--font list` that checks `vga16` and `courier` are present.
+:Done when: Font listing has one implementation and a stable testable output shape.
+:END:
+
+* TODO [#A] Add startup CLI and config support
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Let users choose the AA render font from CLI, TOML, and environment while preserving current precedence and AA-lib option parsing.
+:Notes: There is already an AA-lib `-font` option parsed before HasciiCam CLI parsing. Keep that working, but add a HasciiCam-level `--font` option because users asked for CLI/config support and `--font list`. Be careful: AA-lib's `aa_parseoptions()` runs before `hasciicam_config_parse()`, so `--font` must not be eaten by AA-lib and `--font list` should exit cleanly before camera/display startup.
+:END:
+
+** TODO [#A] Add canonical `font` config key
+:PROPERTIES:
+:Why: TOML/env need a concise canonical key, and `font_face` already means HTML CSS font face, not AA-lib bitmap font.
+:Change: Add `char font[64]` or similarly named field to `hasciicam_config`. Use canonical key `font` for env/TOML. Do not reuse `font_face`; document the distinction: `font` is AA-lib bitmap rendering font, `font_face` is HTML CSS output face. Initialize to `vga16` or empty plus default helper; prefer storing `vga16` after parsing so the GUI can show a selected combo item.
+:Tests: Extend `tests/test_app_config.c` to load `font = "vga8"` from TOML/env and to save it back. Add rejection tests for an unknown font.
+:Done when: Config can persist and load a font short name and rejects invalid names before render startup.
+:END:
+
+** TODO [#A] Add `--font NAME` and `--font list`
+:PROPERTIES:
+:Why: Users need a direct startup option and a discoverability path for available font names.
+:Change: Add long option `--font` with required argument to `src/app/app_config.c`. If value is `list`, print the font list to stdout or stderr consistently with existing help behavior, then exit 0 before camera/display startup. Otherwise validate the value through the font API and store the short name in config. Avoid a short option because legacy `-f` was historically FTP in docs and AA-lib already has `-font`; adding a new short alias risks confusion. Keep `-font` AA-lib compatibility unchanged if it currently works. If both AA-lib `-font` and HasciiCam `--font` are supplied, HasciiCam config precedence should win by assigning `render_session.hwparams.font` after `hasciicam_config_parse()`.
+:Tests: Add CLI tests: `hasciicam --font list` exits 0 and prints known short names; `hasciicam --font vga8 -d synthetic:// --frames 1 -m text -o ...` exits 0; `hasciicam --font no-such-font -h` or equivalent parse-only command exits nonzero with a useful error. Ensure `hasciicam -H` still shows AA-lib help and current tests pass.
+:Done when: Font selection is available from CLI, `--font list` is implemented, bad names fail early, and existing AA-lib option parsing remains compatible.
+:END:
+
+** TODO [#B] Apply configured font before opening AA-lib
+:PROPERTIES:
+:Why: AA-lib uses `hwparams.font` during context initialization and buffer sizing. The configured font must be applied before `hasciicam_render_session_open()`.
+:Change: Add `hasciicam_render_session_set_font_by_name()` or equivalent, using the font API to set `render_session.hwparams.font`. Call it in `src/hasciicam.c` after HasciiCam config parsing and before size planning/render session open. Update size metrics before capture negotiation: display cell height should come from the selected font height, and width should remain 8 unless a future AA-lib font API exposes width. Rebuild `hasciicam_size_metrics` after font selection so `--size` pixel intent and default live sizing derive the correct ASCII grid.
+:Tests: Add or extend app size tests so a font with height 8 (`vga8`) produces more rows for the same pixel target than `vga16`. Add a CLI smoke that selects `vga8` and text output using synthetic capture.
+:Done when: Startup selected font affects AA-lib render context, size planning, and output without needing a camera.
+:END:
+
+* TODO [#A] Make SDL live font switching safe
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Allow changing fonts from the right-click GUI combo box in live SDL mode without crashes, stale textures, stale buffers, or invalid capture/frame sizes.
+:Notes: This is the risky part. `aa_setfont()` invalidates AA-lib render tables, but the SDL driver also caches `d->font`, `char_width`, `char_height`, `font_texture`, stream texture, previous text/attr buffers, and content offsets. Changing only `c->params.font` is insufficient. Prefer an explicit SDL bridge function that owns driver-side refresh.
+:END:
+
+** TODO [#A] Add font fields and change request to GUI state
+:PROPERTIES:
+:Why: The C++ ImGui adapter should not call AA-lib directly; it should only update state and request an application-level change.
+:Change: Extend `hasciicam_gui_state` with current font short name, selected font index or short name, and a one-shot `font_change_requested` flag. Initialize from config/current render font. Copy current font back to config for save/load. When config is loaded from the GUI, refresh the selected font field and request a live apply if the loaded font differs from the current one.
+:Tests: Extend `test_gui_state.c` to cover init/copy of `font`, requested change flag behavior, and load-state preservation of save/load paths.
+:Done when: GUI state can represent font selection and save/load it without linking SDL or ImGui.
+:END:
+
+** TODO [#A] Add the ImGui font combo box
+:PROPERTIES:
+:Why: Users need live mode selection from the available bundled fonts.
+:Change: In `src/gui/gui_overlay.cpp`, add a combo box under a display/rendering section. Populate it from the font catalog API, showing short names and optionally long names in the label. On selection, write the selected short name into GUI state and set `font_change_requested = 1`. Use stable indices each frame; do not allocate per-frame strings. If the font catalog API is C-only, expose a C function suitable for C++ calls.
+:Tests: Build GUI on Windows vcpkg preset. Manual visual smoke: run SDL synthetic mode, open the panel, confirm the combo is populated and selecting another font does not close or corrupt the panel.
+:Done when: The GUI displays all registered fonts and emits a single clear change request when the selection changes.
+:END:
+
+** TODO [#A] Implement an SDL font-switch bridge
+:PROPERTIES:
+:Why: SDL live output must rebuild driver-side font resources in one place, not through scattered app code.
+:Change: Add a bridge function such as `hasciicam_sdl_set_runtime_font(aa_context *, const char *shortname, int *out_ascii_w, int *out_ascii_h)`. In the SDL implementation, validate active driver is SDL, find the font, call `aa_setfont(context, font)`, update `struct sdldriverdata`: `d->font = font`, `d->char_width = 8`, `d->char_height = font->height`, destroy/recreate `font_texture`, destroy/recreate stream texture, clear `previoust` and `previousa`, set `force_clear = 1`, recompute window-derived `d->width`/`d->height` in character cells, update AA context size through `aa_resize(context)` if needed, and report resulting `aa_imgwidth()`/`aa_imgheight()`. Ensure all allocations are checked and that failure leaves the previous font usable where possible. Keep stub implementation returning false when SDL/GUI is off.
+:Tests: Add a non-window unit test for font lookup; for the SDL bridge, use a visual/smoke test only unless existing visual SDL CTest can be enabled locally. Run `hasciicam -q -d synthetic:// -O SDL --frames 2 --font vga8` and `--font vga16`. Manually exercise live switching with a real or synthetic stream for several font changes.
+:Done when: Switching fonts live recreates SDL font/stream resources, keeps rendering, and has no stale texture or buffer access.
+:END:
+
+** TODO [#A] Reconcile live resize with capture and grayscale buffers
+:PROPERTIES:
+:Why: Changing font height changes how many ASCII rows fit in the same SDL window. The render loop currently asks capture conversion for `aa_imgwidth()`/`aa_imgheight()` and copies into AA image memory; if those dimensions change, the gray frame allocation and copy bounds must remain valid.
+:Change: Audit `hasciicam_session_step()`, gray buffer ownership, and `aa_resize()`. If `aa_imgwidth()`/`aa_imgheight()` changes after a live font switch, ensure the next frame conversion allocates or returns a gray buffer of the new size and the app recomputes `dest_size` each frame as it already does. If any cached dimensions exist outside AA-lib/SDL, update them after successful font switch. Do not reopen the camera for live font changes in the first implementation; instead, keep the capture backend resolution fixed and resample the current camera frame into the new AA image dimensions. Revisit only if tests show poor sizing.
+:Tests: Add or extend a synthetic-session test if possible to render a frame, switch the render context font/size through a test helper, render another frame, and assert no crash and non-empty output. If direct context switching is too coupled to SDL, document this as manual SDL smoke and rely on live test commands.
+:Done when: Live font switching never writes past image/text/attr buffers and does not require camera reopen.
+:END:
+
+** TODO [#B] Keep final video output sizing predictable
+:PROPERTIES:
+:Why: User expectations differ: changing font may mean more rows/cols in the same window, or same rows/cols with a resized window. The least surprising live behavior is to keep the SDL window pixel size stable and recompute the ASCII grid from the new cell height.
+:Change: For live SDL switching, keep the current window pixel size and derive `d->width = window_width / 8`, `d->height = window_height / font->height`. This means smaller fonts show more rows in the same window; larger fonts show fewer rows. For startup `--font`, apply the same metrics before size planning. For text/HTML output, the font affects AA-lib glyph analysis and render tables, but not terminal text cell dimensions; do not alter output file dimensions unless `--size` pixel intent is being converted through display metrics for live SDL.
+:Tests: Size tests for pixel-intent startup metrics. Manual SDL check: switch `vga16` to `vga8` and confirm the window stays the same pixel size while more rows are visible.
+:Done when: Font size behavior is documented and implemented consistently across startup and live SDL mode.
+:END:
+
+* TODO [#B] Persist, document, and verify the feature
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Make font selection discoverable, saved, loaded, tested, and documented without disturbing existing rendering paths.
+:Notes: Keep docs concise. This is a user-facing option, so update help, man page, README, and AGENTS. Do not update generated website docs unless that is already part of the repo workflow.
+:END:
+
+** TODO [#A] Save and load font in TOML
+:PROPERTIES:
+:Why: The GUI Save/Load buttons and startup config should round-trip the selected font.
+:Change: Include `font` in the persisted config keys. Saving writes the short name, for example `font = "vga16"`. Loading validates through the font catalog; if invalid, fail the load with an actionable message and leave live state unchanged. For GUI load, keep current save/load paths preserved as the existing GUI code does.
+:Tests: Extend TOML round-trip tests to include `font = "courier"` or `vga8`. Add load failure test for `font = "missing"`.
+:Done when: TOML can persist a selected font and invalid font config does not silently fall back.
+:END:
+
+** TODO [#B] Update user-facing docs and help
+:PROPERTIES:
+:Why: Users need to know `--font list`, valid config key, and live GUI behavior.
+:Change: Update `src/app/app_config.c` help text, `docs/hasciicam.1`, `README.md`, and `AGENTS.md`. Add `font` to canonical config keys. Describe `--font NAME`, `--font list`, and live GUI font combo. Clarify that `--font-face` remains HTML CSS font face and is unrelated to AA-lib bitmap font selection.
+:Tests: Existing `cli_help` and `cli_aahelp` tests should still pass. Add or update a CLI help assertion only if current CTest checks exact text elsewhere.
+:Done when: Help and docs describe the new option without confusing it with HTML `font_face`.
+:END:
+
+** TODO [#A] Full verification on Windows vcpkg preset
+:PROPERTIES:
+:Why: The requested target is Windows first, and SDL/GUI/font switching are platform-sensitive.
+:Change: Run the standard Windows commands from a Visual Studio environment: `cmake --preset windows-vcpkg-ninja`, `cmake --build --preset windows-vcpkg-ninja`, and `ctest --preset windows-vcpkg-ninja`. Then run focused manual commands: `hasciicam --font list`, `hasciicam -q -d synthetic:// --frames 2 -m text --font vga8 -o ...`, `hasciicam -q -d synthetic:// -O SDL --frames 2 --font vga8`, and one interactive SDL session where fonts are changed repeatedly from the combo box.
+:Tests: Full CTest plus the manual smoke commands above. Record any manual limitation in the final reviewer summary.
+:Done when: Automated tests pass, CLI list works, startup font selection works, and live SDL switching has been exercised without crash.
+:END:
+
+** TODO [#C] Keep follow-up scope explicit
+:PROPERTIES:
+:Why: Font switching touches sizing and can invite broader renderer refactors; this plan should stay minimal.
+:Change: Do not add proportional fonts, external font loading, TTF rendering, ImGui fonts, or platform-native font pickers. Do not change HTML `font_face` behavior beyond documentation. If future work wants external fonts, create a separate plan after this one is stable.
+:Tests: No code tests.
+:Done when: The implementation stays limited to bundled AA-lib fonts and the requested CLI/config/GUI surfaces.
+:END:

--- a/.gestalt/plans/font-selection.org
+++ b/.gestalt/plans/font-selection.org
@@ -18,7 +18,7 @@
 :Done when: All code that needs a font can use one helper API, and tests prove lookup behavior without opening SDL or a camera.
 :END:
 
-** TODO [#A] Decide the canonical default font
+** DONE [#A] Decide the canonical default font
 :PROPERTIES:
 :Why: The current default is implicit: AA-lib/SDL fall back to `aa_font16`, but config and GUI need an explicit value to show.
 :Change: Define the default font short name as `vga16` in the new font API. Keep behavior unchanged when no font is configured. During render session initialization, keep `hwparams.font = NULL` unless a configured font is selected; this preserves driver defaults. When exposing the current value to config/GUI, report `vga16` if the context or hardware params have no explicit font and SDL would use its fallback.
@@ -26,7 +26,7 @@
 :Done when: The UI and saved TOML have a stable default name while runtime rendering remains backward-compatible.
 :END:
 
-** TODO [#B] Add a font listing formatter
+** DONE [#B] Add a font listing formatter
 :PROPERTIES:
 :Why: `--font list` should be deterministic, readable, and reusable in tests without duplicating print code in the parser.
 :Change: Add a helper that writes all fonts to a `FILE *`, one font per line, with the short name first. Suggested format: `vga16\tStandard vga 8x16 font\t8x16`. Width is always 8 for these AA-lib bitmap fonts; height comes from `font->height`. Do not promise that all future fonts are width 8 unless the AA-lib `aa_font` structure remains width-less.
@@ -34,14 +34,14 @@
 :Done when: Font listing has one implementation and a stable testable output shape.
 :END:
 
-* TODO [#A] Add startup CLI and config support
+* DONE [#A] Add startup CLI and config support
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Let users choose the AA render font from CLI, TOML, and environment while preserving current precedence and AA-lib option parsing.
 :Notes: There is already an AA-lib `-font` option parsed before HasciiCam CLI parsing. Keep that working, but add a HasciiCam-level `--font` option because users asked for CLI/config support and `--font list`. Be careful: AA-lib's `aa_parseoptions()` runs before `hasciicam_config_parse()`, so `--font` must not be eaten by AA-lib and `--font list` should exit cleanly before camera/display startup.
 :END:
 
-** TODO [#A] Add canonical `font` config key
+** DONE [#A] Add canonical `font` config key
 :PROPERTIES:
 :Why: TOML/env need a concise canonical key, and `font_face` already means HTML CSS font face, not AA-lib bitmap font.
 :Change: Add `char font[64]` or similarly named field to `hasciicam_config`. Use canonical key `font` for env/TOML. Do not reuse `font_face`; document the distinction: `font` is AA-lib bitmap rendering font, `font_face` is HTML CSS output face. Initialize to `vga16` or empty plus default helper; prefer storing `vga16` after parsing so the GUI can show a selected combo item.
@@ -49,7 +49,7 @@
 :Done when: Config can persist and load a font short name and rejects invalid names before render startup.
 :END:
 
-** TODO [#A] Add `--font NAME` and `--font list`
+** DONE [#A] Add `--font NAME` and `--font list`
 :PROPERTIES:
 :Why: Users need a direct startup option and a discoverability path for available font names.
 :Change: Add long option `--font` with required argument to `src/app/app_config.c`. If value is `list`, print the font list to stdout or stderr consistently with existing help behavior, then exit 0 before camera/display startup. Otherwise validate the value through the font API and store the short name in config. Avoid a short option because legacy `-f` was historically FTP in docs and AA-lib already has `-font`; adding a new short alias risks confusion. Keep `-font` AA-lib compatibility unchanged if it currently works. If both AA-lib `-font` and HasciiCam `--font` are supplied, HasciiCam config precedence should win by assigning `render_session.hwparams.font` after `hasciicam_config_parse()`.
@@ -57,7 +57,7 @@
 :Done when: Font selection is available from CLI, `--font list` is implemented, bad names fail early, and existing AA-lib option parsing remains compatible.
 :END:
 
-** TODO [#B] Apply configured font before opening AA-lib
+** DONE [#B] Apply configured font before opening AA-lib
 :PROPERTIES:
 :Why: AA-lib uses `hwparams.font` during context initialization and buffer sizing. The configured font must be applied before `hasciicam_render_session_open()`.
 :Change: Add `hasciicam_render_session_set_font_by_name()` or equivalent, using the font API to set `render_session.hwparams.font`. Call it in `src/hasciicam.c` after HasciiCam config parsing and before size planning/render session open. Update size metrics before capture negotiation: display cell height should come from the selected font height, and width should remain 8 unless a future AA-lib font API exposes width. Rebuild `hasciicam_size_metrics` after font selection so `--size` pixel intent and default live sizing derive the correct ASCII grid.
@@ -65,14 +65,14 @@
 :Done when: Startup selected font affects AA-lib render context, size planning, and output without needing a camera.
 :END:
 
-* TODO [#A] Make SDL live font switching safe
+* WIP [#A] Make SDL live font switching safe
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Allow changing fonts from the right-click GUI combo box in live SDL mode without crashes, stale textures, stale buffers, or invalid capture/frame sizes.
 :Notes: This is the risky part. `aa_setfont()` invalidates AA-lib render tables, but the SDL driver also caches `d->font`, `char_width`, `char_height`, `font_texture`, stream texture, previous text/attr buffers, and content offsets. Changing only `c->params.font` is insufficient. Prefer an explicit SDL bridge function that owns driver-side refresh.
 :END:
 
-** TODO [#A] Add font fields and change request to GUI state
+** DONE [#A] Add font fields and change request to GUI state
 :PROPERTIES:
 :Why: The C++ ImGui adapter should not call AA-lib directly; it should only update state and request an application-level change.
 :Change: Extend `hasciicam_gui_state` with current font short name, selected font index or short name, and a one-shot `font_change_requested` flag. Initialize from config/current render font. Copy current font back to config for save/load. When config is loaded from the GUI, refresh the selected font field and request a live apply if the loaded font differs from the current one.
@@ -80,7 +80,7 @@
 :Done when: GUI state can represent font selection and save/load it without linking SDL or ImGui.
 :END:
 
-** TODO [#A] Add the ImGui font combo box
+** DONE [#A] Add the ImGui font combo box
 :PROPERTIES:
 :Why: Users need live mode selection from the available bundled fonts.
 :Change: In `src/gui/gui_overlay.cpp`, add a combo box under a display/rendering section. Populate it from the font catalog API, showing short names and optionally long names in the label. On selection, write the selected short name into GUI state and set `font_change_requested = 1`. Use stable indices each frame; do not allocate per-frame strings. If the font catalog API is C-only, expose a C function suitable for C++ calls.
@@ -88,7 +88,7 @@
 :Done when: The GUI displays all registered fonts and emits a single clear change request when the selection changes.
 :END:
 
-** TODO [#A] Implement an SDL font-switch bridge
+** DONE [#A] Implement an SDL font-switch bridge
 :PROPERTIES:
 :Why: SDL live output must rebuild driver-side font resources in one place, not through scattered app code.
 :Change: Add a bridge function such as `hasciicam_sdl_set_runtime_font(aa_context *, const char *shortname, int *out_ascii_w, int *out_ascii_h)`. In the SDL implementation, validate active driver is SDL, find the font, call `aa_setfont(context, font)`, update `struct sdldriverdata`: `d->font = font`, `d->char_width = 8`, `d->char_height = font->height`, destroy/recreate `font_texture`, destroy/recreate stream texture, clear `previoust` and `previousa`, set `force_clear = 1`, recompute window-derived `d->width`/`d->height` in character cells, update AA context size through `aa_resize(context)` if needed, and report resulting `aa_imgwidth()`/`aa_imgheight()`. Ensure all allocations are checked and that failure leaves the previous font usable where possible. Keep stub implementation returning false when SDL/GUI is off.

--- a/.gestalt/plans/font-selection.org
+++ b/.gestalt/plans/font-selection.org
@@ -3,7 +3,7 @@
 #+DATE: 2026-06-01
 #+KEYWORDS: font aalib cli config gui sdl resize live
 
-* WIP [#A] Define a small AA font catalog API
+* DONE [#A] Define a small AA font catalog API
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Provide one tested C API for listing, looking up, and describing bundled AA-lib fonts without exposing callers to direct `aa_fonts[]` iteration.
@@ -65,7 +65,7 @@
 :Done when: Startup selected font affects AA-lib render context, size planning, and output without needing a camera.
 :END:
 
-* WIP [#A] Make SDL live font switching safe
+* DONE [#A] Make SDL live font switching safe
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Allow changing fonts from the right-click GUI combo box in live SDL mode without crashes, stale textures, stale buffers, or invalid capture/frame sizes.
@@ -96,7 +96,7 @@
 :Done when: Switching fonts live recreates SDL font/stream resources, keeps rendering, and has no stale texture or buffer access.
 :END:
 
-** TODO [#A] Reconcile live resize with capture and grayscale buffers
+** DONE [#A] Reconcile live resize with capture and grayscale buffers
 :PROPERTIES:
 :Why: Changing font height changes how many ASCII rows fit in the same SDL window. The render loop currently asks capture conversion for `aa_imgwidth()`/`aa_imgheight()` and copies into AA image memory; if those dimensions change, the gray frame allocation and copy bounds must remain valid.
 :Change: Audit `hasciicam_session_step()`, gray buffer ownership, and `aa_resize()`. If `aa_imgwidth()`/`aa_imgheight()` changes after a live font switch, ensure the next frame conversion allocates or returns a gray buffer of the new size and the app recomputes `dest_size` each frame as it already does. If any cached dimensions exist outside AA-lib/SDL, update them after successful font switch. Do not reopen the camera for live font changes in the first implementation; instead, keep the capture backend resolution fixed and resample the current camera frame into the new AA image dimensions. Revisit only if tests show poor sizing.
@@ -104,7 +104,7 @@
 :Done when: Live font switching never writes past image/text/attr buffers and does not require camera reopen.
 :END:
 
-** TODO [#B] Keep final video output sizing predictable
+** DONE [#B] Keep final video output sizing predictable
 :PROPERTIES:
 :Why: User expectations differ: changing font may mean more rows/cols in the same window, or same rows/cols with a resized window. The least surprising live behavior is to keep the SDL window pixel size stable and recompute the ASCII grid from the new cell height.
 :Change: For live SDL switching, keep the current window pixel size and derive `d->width = window_width / 8`, `d->height = window_height / font->height`. This means smaller fonts show more rows in the same window; larger fonts show fewer rows. For startup `--font`, apply the same metrics before size planning. For text/HTML output, the font affects AA-lib glyph analysis and render tables, but not terminal text cell dimensions; do not alter output file dimensions unless `--size` pixel intent is being converted through display metrics for live SDL.
@@ -112,14 +112,14 @@
 :Done when: Font size behavior is documented and implemented consistently across startup and live SDL mode.
 :END:
 
-* TODO [#B] Persist, document, and verify the feature
+* DONE [#B] Persist, document, and verify the feature
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Make font selection discoverable, saved, loaded, tested, and documented without disturbing existing rendering paths.
 :Notes: Keep docs concise. This is a user-facing option, so update help, man page, README, and AGENTS. Do not update generated website docs unless that is already part of the repo workflow.
 :END:
 
-** TODO [#A] Save and load font in TOML
+** DONE [#A] Save and load font in TOML
 :PROPERTIES:
 :Why: The GUI Save/Load buttons and startup config should round-trip the selected font.
 :Change: Include `font` in the persisted config keys. Saving writes the short name, for example `font = "vga16"`. Loading validates through the font catalog; if invalid, fail the load with an actionable message and leave live state unchanged. For GUI load, keep current save/load paths preserved as the existing GUI code does.
@@ -127,7 +127,7 @@
 :Done when: TOML can persist a selected font and invalid font config does not silently fall back.
 :END:
 
-** TODO [#B] Update user-facing docs and help
+** DONE [#B] Update user-facing docs and help
 :PROPERTIES:
 :Why: Users need to know `--font list`, valid config key, and live GUI behavior.
 :Change: Update `src/app/app_config.c` help text, `docs/hasciicam.1`, `README.md`, and `AGENTS.md`. Add `font` to canonical config keys. Describe `--font NAME`, `--font list`, and live GUI font combo. Clarify that `--font-face` remains HTML CSS font face and is unrelated to AA-lib bitmap font selection.
@@ -135,7 +135,7 @@
 :Done when: Help and docs describe the new option without confusing it with HTML `font_face`.
 :END:
 
-** TODO [#A] Full verification on Windows vcpkg preset
+** DONE [#A] Full verification on Windows vcpkg preset
 :PROPERTIES:
 :Why: The requested target is Windows first, and SDL/GUI/font switching are platform-sensitive.
 :Change: Run the standard Windows commands from a Visual Studio environment: `cmake --preset windows-vcpkg-ninja`, `cmake --build --preset windows-vcpkg-ninja`, and `ctest --preset windows-vcpkg-ninja`. Then run focused manual commands: `hasciicam --font list`, `hasciicam -q -d synthetic:// --frames 2 -m text --font vga8 -o ...`, `hasciicam -q -d synthetic:// -O SDL --frames 2 --font vga8`, and one interactive SDL session where fonts are changed repeatedly from the combo box.
@@ -143,7 +143,7 @@
 :Done when: Automated tests pass, CLI list works, startup font selection works, and live SDL switching has been exercised without crash.
 :END:
 
-** TODO [#C] Keep follow-up scope explicit
+** DONE [#C] Keep follow-up scope explicit
 :PROPERTIES:
 :Why: Font switching touches sizing and can invite broader renderer refactors; this plan should stay minimal.
 :Change: Do not add proportional fonts, external font loading, TTF rendering, ImGui fonts, or platform-native font pickers. Do not change HTML `font_face` behavior beyond documentation. If future work wants external fonts, create a separate plan after this one is stable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ The current path in `src/hasciicam.c` is:
 
 1. Install `SIGINT` handling through `quitproc()`.
 2. Initialize AA-lib defaults and let AA-lib parse AA options with `aa_parseoptions()`.
-3. Parse HasciiCam CLI options in `config_init()`.
+3. Load startup config, then parse HasciiCam env/CLI options in `config_init()`.
 4. Build a `capture_request` and open capture through `capture_open_default()`:
    - Windows order: Media Foundation, then DirectShow fallback.
    - Non-Windows order: V4L2.
@@ -153,6 +153,8 @@ Core options:
 - `-o`, `--aafile`: HTML/text output file.
 - `-O`, `--aadriver`: preferred live AA-lib driver, such as `SDL`, `X11`,
   `curses`, or `stdout`.
+- `--config`: load a startup TOML config file instead of auto-discovering
+  `hasciicam.toml` in the current working directory.
 - `-D`, `--daemon`: run in the background on Unix-like systems.
 - `-U`, `--uid` and `-G`, `--gid`: drop privileges.
 
@@ -173,11 +175,13 @@ changing CLI parsing, preserve that ordering.
 
 ## Launch Configuration
 
-HasciiCam launch config supports three sources:
+HasciiCam launch config supports four sources:
 
 1. Defaults from `hasciicam_config_init_defaults()`
-2. Lowercase environment variables with canonical config-key names
-3. Command-line options (highest precedence)
+2. Startup TOML: explicit `--config path` or `hasciicam.toml` in the current
+   working directory when present
+3. Lowercase environment variables with canonical config-key names
+4. Command-line options (highest precedence)
 
 Canonical config keys:
 
@@ -363,8 +367,8 @@ Internal config file APIs are declared in `src/app/app_config.h`:
 - `hasciicam_config_save_toml(...)`
 
 TOML parsing uses vendored `cktan/tomlc17` source in `src/app/tomlc17/`.
-Current startup does not auto-load a TOML file and does not implement CLI
-`--config` discovery.
+Startup auto-loads `hasciicam.toml` from the current working directory when
+present. `--config path` loads a specific TOML file instead.
 
 ## Portability Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ Rendering options:
 
 - `-S`, `--font-size`: HTML font size.
 - `-a`, `--font-face`: HTML font face.
+- `--font`: AA bitmap font selection (`--font list` to enumerate).
 - `-r`, `--refresh`: HTML refresh interval.
 - `-b`, `--aabright`: AA brightness.
 - `-c`, `--aacontrast`: AA contrast.
@@ -196,6 +197,7 @@ Canonical config keys:
 - `daemon`
 - `font_size`
 - `font_face`
+- `font`
 - `refresh`
 - `aa_bright`
 - `aa_contrast`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,15 @@ if(HASCIICAM_ENABLE_TESTS)
   add_test(NAME app_size COMMAND test_app_size)
   set_tests_properties(app_size PROPERTIES LABELS "unit;core")
 
+  add_executable(test_render_font
+    tests/test_render_font.c
+    src/render/render_font.c
+  )
+  target_include_directories(test_render_font PRIVATE src/render src/aalib)
+  target_link_libraries(test_render_font PRIVATE aalib)
+  add_test(NAME render_font COMMAND test_render_font)
+  set_tests_properties(render_font PROPERTIES LABELS "unit;core")
+
   add_executable(test_app_config
     tests/test_app_config.c
     src/app/app_config.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,15 @@ if(HASCIICAM_ENABLE_TESTS)
     set_tests_properties(cli_render_tuning PROPERTIES LABELS "cli")
 
     add_test(
+      NAME cli_config_startup
+      COMMAND ${CMAKE_COMMAND}
+        -DHASCIICAM_EXE=$<TARGET_FILE:hasciicam>
+        -DHASCIICAM_OUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cli_config_startup.cmake
+    )
+    set_tests_properties(cli_config_startup PROPERTIES LABELS "cli")
+
+    add_test(
       NAME cli_size_pixel
       COMMAND ${CMAKE_COMMAND}
         -DHASCIICAM_EXE=$<TARGET_FILE:hasciicam>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,15 +288,20 @@ if(HASCIICAM_ENABLE_TESTS)
   )
   target_include_directories(test_render_font PRIVATE src/render src/aalib)
   target_link_libraries(test_render_font PRIVATE aalib)
+  if(WIN32)
+    target_compile_definitions(test_render_font PRIVATE _CRT_SECURE_NO_WARNINGS)
+  endif()
   add_test(NAME render_font COMMAND test_render_font)
   set_tests_properties(render_font PROPERTIES LABELS "unit;core")
 
   add_executable(test_app_config
     tests/test_app_config.c
     src/app/app_config.c
+    src/render/render_font.c
     src/app/tomlc17/tomlc17.c
   )
-  target_include_directories(test_app_config PRIVATE src/app)
+  target_include_directories(test_app_config PRIVATE src/app src/render src/aalib)
+  target_link_libraries(test_app_config PRIVATE aalib)
   if(WIN32)
     target_sources(test_app_config PRIVATE src/compat/getopt.c)
     target_include_directories(test_app_config PRIVATE src/compat)
@@ -394,6 +399,15 @@ if(HASCIICAM_ENABLE_TESTS)
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cli_config_startup.cmake
     )
     set_tests_properties(cli_config_startup PROPERTIES LABELS "cli")
+
+    add_test(
+      NAME cli_font_options
+      COMMAND ${CMAKE_COMMAND}
+        -DHASCIICAM_EXE=$<TARGET_FILE:hasciicam>
+        -DHASCIICAM_OUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cli_font_options.cmake
+    )
+    set_tests_properties(cli_font_options PROPERTIES LABELS "cli")
 
     add_test(
       NAME cli_size_pixel

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ HasciiCam can show an optional on-screen control panel in live SDL mode.
 
 - Build toggle: `HASCIICAM_ENABLE_GUI` (requires SDL and vendored Dear ImGui under `third_party/imgui/`)
 - Activation: right mouse click in the SDL window
-- Live controls: AA brightness/contrast/gamma, invert, mirror, foreground/background colors
+- Live controls: AA brightness/contrast/gamma, invert, mirror, foreground/background colors, AA font
 - Config actions: `Save` writes TOML, `Load` reads TOML
 
 File chooser behavior:
@@ -59,6 +59,13 @@ Configuration precedence is:
 2. Startup TOML (`hasciicam.toml` or `--config`)
 3. Lowercase environment variables using canonical config-key names
 4. Command-line options
+
+Font selection:
+
+- `--font list` prints all bundled AA bitmap fonts (short names)
+- `--font <name>` selects one startup AA font (for example `vga16`, `vga8`, `courier`)
+- `font = "vga16"` in TOML/env sets the same AA bitmap font
+- `--font-face` remains HTML CSS font face (different from AA bitmap `font`)
 
 ## Runtime Pipeline (2.0)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ File chooser behavior:
 - Windows: native `GetOpenFileNameW` dialog
 - Other platforms: fallback path field in the panel
 
+## Startup Configuration
+
+At startup, HasciiCam checks for `hasciicam.toml` in the current working
+directory and loads it when present. Use `--config path/to/file.toml` to load a
+specific TOML file instead.
+
+Configuration precedence is:
+
+1. Built-in defaults
+2. Startup TOML (`hasciicam.toml` or `--config`)
+3. Lowercase environment variables using canonical config-key names
+4. Command-line options
+
 ## Runtime Pipeline (2.0)
 
 The executable pipeline is split into explicit capture and conversion stages:
@@ -55,7 +68,7 @@ The executable pipeline is split into explicit capture and conversion stages:
 2. Open a capture backend through `src/capture/capture_backend.c`.
 3. Read frames through the backend `capture_ops` contract in `src/capture/capture.h`.
 4. Convert backend pixel formats to grayscale via `src/capture/frame_convert.c`.
-5. Write grayscale into AA-lib image memory and render ASCII with `aa_fastrender`.
+5. Write grayscale into AA-lib image memory and render ASCII with AA render params.
 6. Flush output through AA-lib driver selection (`SDL`, `stdout`, save drivers).
 
 This keeps platform camera code out of the render path and lets new backends

--- a/cmake/HasciiCamSources.cmake
+++ b/cmake/HasciiCamSources.cmake
@@ -67,6 +67,7 @@ set(HASCIICAM_OUTPUT_SOURCES
 )
 
 set(HASCIICAM_RENDER_SOURCES
+    src/render/render_font.c
     src/render/render_session.c
 )
 

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -84,6 +84,10 @@ Use \fB--mirror -x\fP to disable horizontal mirroring, and \fB--mirror y\fP to a
 Loads startup configuration from the given TOML file.
 If omitted, HasciiCam checks for \fBhasciicam.toml\fP in the current working directory and loads it when present.
 .B
+.IP "--font"
+Selects the bundled AA-lib bitmap font by short name, or prints available fonts with \fB--font list\fP.
+Example names include \fBvga16\fP, \fBvga8\fP, and \fBcourier\fP.
+.B
 .IP "-o --aafile"
 Defines the file where to save rendered ascii, overwrited every \fIrefresh\fP seconds. Default is \fBhasciicam.html\fP when in \fBhtml\fP mode, \fBhasciicam.asc\fP when in \fBtext\fP mode (useless when in \fBlive\fP mode).
 .B
@@ -158,7 +162,7 @@ Canonical keys:
 .br
 \fBfont_size font_face refresh aa_bright aa_contrast aa_gamma invert\fP
 .br
-\fBbackground foreground uid gid frames sdl_renderer sdl_vsync fullscreen mirror\fP
+\fBbackground foreground font uid gid frames sdl_renderer sdl_vsync fullscreen mirror\fP
 .SH CONFIG FILES
 HasciiCam loads \fBhasciicam.toml\fP from the current working directory at
 startup when it exists. Use \fB--config path/to/file.toml\fP to load a specific

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -80,6 +80,10 @@ Accepted values are \fBx\fP, \fB-x\fP, \fBy\fP, and \fB-y\fP.
 Horizontal mirror \fBx\fP is enabled by default so live preview behaves like a mirror.
 Use \fB--mirror -x\fP to disable horizontal mirroring, and \fB--mirror y\fP to add vertical mirroring.
 .B
+.IP "--config"
+Loads startup configuration from the given TOML file.
+If omitted, HasciiCam checks for \fBhasciicam.toml\fP in the current working directory and loads it when present.
+.B
 .IP "-o --aafile"
 Defines the file where to save rendered ascii, overwrited every \fIrefresh\fP seconds. Default is \fBhasciicam.html\fP when in \fBhtml\fP mode, \fBhasciicam.asc\fP when in \fBtext\fP mode (useless when in \fBlive\fP mode).
 .B
@@ -133,8 +137,8 @@ puts your ascii into your local .plan (fingercam)
 generates an hascii video with font size +1 and uploads the frames in ftp passive mode on the dyne.org server, with user jaromil password sasuchen, inside the korova directory
 .SH ENVIRONMENT
 HasciiCam also accepts launch configuration from lowercase environment
-variables that match canonical config keys. Command-line options have higher
-precedence than environment variables.
+variables that match canonical config keys. Startup TOML is loaded before
+environment variables, and command-line options have highest precedence.
 .IP
 Examples:
 .br
@@ -156,8 +160,9 @@ Canonical keys:
 .br
 \fBbackground foreground uid gid frames sdl_renderer sdl_vsync fullscreen mirror\fP
 .SH CONFIG FILES
-Internal APIs can load/save TOML config files using the vendored
-\fBcktan/tomlc17\fP parser. Current CLI startup does not auto-load TOML.
+HasciiCam loads \fBhasciicam.toml\fP from the current working directory at
+startup when it exists. Use \fB--config path/to/file.toml\fP to load a specific
+TOML file instead.
 .IP
 Example TOML:
 .nf

--- a/src/aalib/aasdl.c
+++ b/src/aalib/aasdl.c
@@ -9,6 +9,7 @@
 #include "aaint.h"
 #include "aasdlint.h"
 #include "../gui/gui_bridge.h"
+#include "../render/render_font.h"
 #if defined(HASCIICAM_ENABLE_GUI)
 #include "../gui/gui_overlay.h"
 #endif
@@ -309,7 +310,7 @@ static void SDL_render_char(struct sdldriverdata *d, unsigned char ch, int x, in
 static void SDL_create_font_texture(struct sdldriverdata *d)
 {
     const int FONT_WIDTH = 8;
-    const int FONT_HEIGHT = 16;
+    const int FONT_HEIGHT = d->font ? d->font->height : 16;
     const int FONT_COLS = 16;
     const int FONT_ROWS = 16;
     
@@ -411,7 +412,7 @@ static int SDL_init(__AA_CONST struct aa_hardware_params *p, __AA_CONST void *no
     dest->font = d->font;
     
     d->char_width = 8;
-    d->char_height = 16;
+    d->char_height = d->font->height;
     
     int win_width = d->width * d->char_width;
     int win_height = d->height * d->char_height;
@@ -811,6 +812,52 @@ int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foregroun
         return 0;
     d = (struct sdldriverdata *)context->driverdata;
     SDL_apply_runtime_colors(d, foreground_rgb, background_rgb);
+    return 1;
+}
+
+int hasciicam_sdl_set_runtime_font(aa_context *context, const char *font_short_name) {
+    struct sdldriverdata *d;
+    hasciicam_font_desc desc;
+    int win_width;
+    int win_height;
+    if (context == NULL || context->driverdata == NULL || font_short_name == NULL)
+        return 0;
+    if (context->driver != &SDL_d)
+        return 0;
+    desc = hasciicam_font_find(font_short_name);
+    if (desc.font == NULL)
+        return 0;
+    d = (struct sdldriverdata *)context->driverdata;
+    if (d->font == desc.font)
+        return 1;
+
+    aa_setfont(context, desc.font);
+    d->font = desc.font;
+    d->char_width = 8;
+    d->char_height = desc.height;
+    if (d->font_texture != NULL) {
+        SDL_DestroyTexture(d->font_texture);
+        d->font_texture = NULL;
+    }
+    SDL_create_font_texture(d);
+    SDL_destroy_stream_texture(d);
+    if (d->previoust != NULL) {
+        free(d->previoust);
+        d->previoust = NULL;
+    }
+    if (d->previousa != NULL) {
+        free(d->previousa);
+        d->previousa = NULL;
+    }
+    SDL_GetWindowSize(d->window, &win_width, &win_height);
+    d->width = win_width / d->char_width;
+    d->height = win_height / d->char_height;
+    if (d->width < 1)
+        d->width = 1;
+    if (d->height < 1)
+        d->height = 1;
+    aa_resize(context);
+    d->force_clear = 1;
     return 1;
 }
 

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -1,4 +1,5 @@
 #include "app_config.h"
+#include "../render/render_font.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -51,6 +52,7 @@ static const struct option long_options[] = {
     {"fullscreen", no_argument, NULL, 1005},
     {"mirror", required_argument, NULL, 1006},
     {"config", required_argument, NULL, 1007},
+    {"font", required_argument, NULL, 1008},
     {"help", no_argument, NULL, 'h'},
     {"aahelp", no_argument, NULL, 'H'},
     {"version", no_argument, NULL, 'v'},
@@ -105,6 +107,7 @@ static const char *help_text =
     "rendering options:\n"
     " -S --font-size    html font size (1-4)      - default 1\n"
     " -a --font-face    html font to use          - default courier\n"
+    "    --font         AA bitmap font name|list  - default vga16\n"
     " -r --refresh      refresh delay             - default 2\n"
     " -b --aabright     ascii brightness          - default 60\n"
     " -c --aacontrast   ascii contrast            - default 4\n"
@@ -129,6 +132,7 @@ static const config_key_desc config_keys[] = {
     {"daemon", CONFIG_VALUE_BOOL, 1, 1},
     {"font_size", CONFIG_VALUE_INT, 1, 1},
     {"font_face", CONFIG_VALUE_STRING, 1, 1},
+    {"font", CONFIG_VALUE_STRING, 1, 1},
     {"refresh", CONFIG_VALUE_INT, 1, 1},
     {"aa_bright", CONFIG_VALUE_INT, 1, 1},
     {"aa_contrast", CONFIG_VALUE_INT, 1, 1},
@@ -446,6 +450,16 @@ static int set_config_value(hasciicam_config *cfg,
         cfg->fontface[sizeof(cfg->fontface) - 1] = '\0';
         return 1;
     }
+    if (strcmp(key, "font") == 0) {
+        hasciicam_font_desc font_desc = hasciicam_font_find(value);
+        if (font_desc.font == 0) {
+            set_error(err, err_size, "invalid value for font: run --font list");
+            return 0;
+        }
+        strncpy(cfg->font, font_desc.short_name, sizeof(cfg->font) - 1);
+        cfg->font[sizeof(cfg->font) - 1] = '\0';
+        return 1;
+    }
     if (strcmp(key, "refresh") == 0) {
         if (!parse_int_value(value, &cfg->refresh)) {
             set_errorf(err, err_size, "invalid value for %s", key);
@@ -624,6 +638,11 @@ static int config_value_as_string(const hasciicam_config *cfg,
         *out_is_quoted = 1;
         return 1;
     }
+    if (strcmp(key, "font") == 0) {
+        snprintf(out, out_size, "%s", cfg->font);
+        *out_is_quoted = 1;
+        return 1;
+    }
     if (strcmp(key, "refresh") == 0) {
         snprintf(out, out_size, "%d", cfg->refresh);
         *out_is_quoted = 0;
@@ -755,6 +774,7 @@ void hasciicam_config_init_defaults(hasciicam_config *cfg) {
     strcpy(cfg->background, "000000");
     strcpy(cfg->foreground, "00FF00");
     strcpy(cfg->fontface, "courier");
+    strcpy(cfg->font, hasciicam_font_default_name());
     strcpy(cfg->aadriver, "");
     strcpy(cfg->sdl_renderer, "");
     strcpy(cfg->aafile, "");
@@ -1063,6 +1083,19 @@ void hasciicam_config_parse(hasciicam_config *cfg,
             }
             break;
         case 1007:
+            break;
+        case 1008:
+            if (strcasecmp(optarg, "list") == 0) {
+                if (!hasciicam_font_write_list(stdout)) {
+                    fprintf(stderr, "!! cannot write font list\n");
+                    exit(1);
+                }
+                exit(0);
+            }
+            if (!set_config_value(cfg, "font", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
             break;
         case 'S':
             if (!set_config_value(cfg, "font_size", optarg, env_err, sizeof(env_err))) {

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -50,6 +50,7 @@ static const struct option long_options[] = {
     {"sdl-vsync", required_argument, NULL, 1004},
     {"fullscreen", no_argument, NULL, 1005},
     {"mirror", required_argument, NULL, 1006},
+    {"config", required_argument, NULL, 1007},
     {"help", no_argument, NULL, 'h'},
     {"aahelp", no_argument, NULL, 'H'},
     {"version", no_argument, NULL, 'v'},
@@ -96,6 +97,7 @@ static const char *help_text =
     "    --sdl-vsync    on|off|auto               - SDL presentation sync\n"
     "    --fullscreen   start SDL live output fullscreen\n"
     "    --mirror       x|-x|y|-y                 - flip image, default x\n"
+    "    --config       load startup TOML config  - default ./hasciicam.toml\n"
     " -D --daemon       run in background         - default foregrond\n"
     "    --frames N     stop after N rendered frames (test/smoke)\n"
     " -U --uid          setuid (int)              - default current\n"
@@ -872,6 +874,54 @@ int hasciicam_config_load_toml(hasciicam_config *cfg,
     return ok;
 }
 
+static int file_exists(const char *path) {
+    FILE *fp = NULL;
+    if (path == NULL || path[0] == '\0')
+        return 0;
+    fp = fopen(path, "rb");
+    if (fp == NULL)
+        return 0;
+    fclose(fp);
+    return 1;
+}
+
+static const char *find_explicit_config_path(int argc, char *argv[]) {
+    int i = 1;
+    for (i = 1; i < argc; ++i) {
+        const char *arg = argv[i];
+        if (arg == NULL)
+            continue;
+        if (strcmp(arg, "--config") == 0) {
+            if (i + 1 >= argc)
+                return "";
+            return argv[i + 1];
+        }
+        if (strncmp(arg, "--config=", 9) == 0)
+            return arg + 9;
+    }
+    return NULL;
+}
+
+static void load_startup_config(hasciicam_config *cfg, int argc, char *argv[]) {
+    char err[200];
+    const char *path = find_explicit_config_path(argc, argv);
+    int explicit_path = path != NULL;
+
+    if (!explicit_path)
+        path = "hasciicam.toml";
+
+    if (path[0] == '\0') {
+        fprintf(stderr, "!! --config requires a path\n");
+        exit(1);
+    }
+    if (!explicit_path && !file_exists(path))
+        return;
+    if (!hasciicam_config_load_toml(cfg, path, err, sizeof(err))) {
+        fprintf(stderr, "!! cannot load config %s: %s\n", path, err);
+        exit(1);
+    }
+}
+
 int hasciicam_config_save_toml(const hasciicam_config *cfg,
                                const char *path,
                                char *err,
@@ -924,6 +974,8 @@ void hasciicam_config_parse(hasciicam_config *cfg,
 
     if (cfg == NULL)
         return;
+
+    load_startup_config(cfg, argc, argv);
 
     if (!hasciicam_config_load_env(cfg, env_err, sizeof(env_err))) {
         fprintf(stderr, "!! %s\n", env_err);
@@ -1009,6 +1061,8 @@ void hasciicam_config_parse(hasciicam_config *cfg,
                 fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }
+            break;
+        case 1007:
             break;
         case 'S':
             if (!set_config_value(cfg, "font_size", optarg, env_err, sizeof(env_err))) {

--- a/src/app/app_config.h
+++ b/src/app/app_config.h
@@ -41,6 +41,7 @@ typedef struct hasciicam_config {
     char aafile[256];
     char background[64];
     char foreground[64];
+    char font[64];
     char fontface[256];
     char aadriver[64];
     char sdl_renderer[32];

--- a/src/gui/gui_bridge.h
+++ b/src/gui/gui_bridge.h
@@ -10,6 +10,7 @@ extern "C" {
 
 int hasciicam_sdl_set_gui_state(aa_context *context, hasciicam_gui_state *state);
 int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foreground_rgb, unsigned int background_rgb);
+int hasciicam_sdl_set_runtime_font(aa_context *context, const char *font_short_name);
 
 #ifdef __cplusplus
 }

--- a/src/gui/gui_bridge_stub.c
+++ b/src/gui/gui_bridge_stub.c
@@ -15,4 +15,10 @@ int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foregroun
     return 0;
 }
 
+int hasciicam_sdl_set_runtime_font(aa_context *context, const char *font_short_name) {
+    (void)context;
+    (void)font_short_name;
+    return 0;
+}
+
 #endif

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -8,6 +8,7 @@
 #include "../../third_party/imgui/imgui.h"
 #include "../../third_party/imgui/backends/imgui_impl_sdl2.h"
 #include "../../third_party/imgui/backends/imgui_impl_sdlrenderer2.h"
+#include "../render/render_font.h"
 
 static int g_initialized = 0;
 
@@ -84,6 +85,44 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     invert = state->invert != 0;
     if (ImGui::Checkbox("Invert", &invert))
         state->invert = invert ? 1 : 0;
+    {
+        int font_count = hasciicam_font_count();
+        int selected_index = -1;
+        int i;
+        for (i = 0; i < font_count; ++i) {
+            hasciicam_font_desc desc = hasciicam_font_at(i);
+            if (desc.short_name != NULL && strcmp(desc.short_name, state->font) == 0) {
+                selected_index = i;
+                break;
+            }
+        }
+        if (selected_index < 0 && font_count > 0) {
+            hasciicam_font_desc first = hasciicam_font_at(0);
+            if (first.short_name != NULL)
+                strncpy(state->font, first.short_name, sizeof(state->font) - 1);
+            selected_index = 0;
+        }
+        if (ImGui::BeginCombo("Font", state->font[0] ? state->font : "(none)")) {
+            for (i = 0; i < font_count; ++i) {
+                hasciicam_font_desc desc = hasciicam_font_at(i);
+                char label[128];
+                bool is_selected;
+                if (desc.short_name == NULL)
+                    continue;
+                snprintf(label, sizeof(label), "%s (%dx%d)", desc.short_name, 8, desc.height);
+                is_selected = (i == selected_index);
+                if (ImGui::Selectable(label, is_selected)) {
+                    strncpy(state->font, desc.short_name, sizeof(state->font) - 1);
+                    state->font[sizeof(state->font) - 1] = '\0';
+                    if (strcmp(state->font, state->active_font) != 0)
+                        state->font_change_requested = 1;
+                }
+                if (is_selected)
+                    ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+    }
 
     ImGui::Separator();
     ImGui::Text("Capture");

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -64,6 +64,8 @@ void hasciicam_gui_state_init(hasciicam_gui_state *state, const hasciicam_config
         state->background_rgb = bg;
     else
         state->background_rgb = 0x000000u;
+    strncpy(state->font, cfg->font, sizeof(state->font) - 1);
+    strncpy(state->active_font, cfg->font, sizeof(state->active_font) - 1);
 
     strncpy(state->save_path, "hasciicam.toml", sizeof(state->save_path) - 1);
     strncpy(state->load_path, "hasciicam.toml", sizeof(state->load_path) - 1);
@@ -78,6 +80,8 @@ void hasciicam_gui_state_copy_to_config(const hasciicam_gui_state *state, hascii
     cfg->invert = state->invert ? 1 : 0;
     cfg->mirror_x = state->mirror_x ? 1 : 0;
     cfg->mirror_y = state->mirror_y ? 1 : 0;
+    strncpy(cfg->font, state->font, sizeof(cfg->font) - 1);
+    cfg->font[sizeof(cfg->font) - 1] = '\0';
     hasciicam_gui_format_rgb_hex(state->background_rgb, cfg->background, sizeof(cfg->background));
     hasciicam_gui_format_rgb_hex(state->foreground_rgb, cfg->foreground, sizeof(cfg->foreground));
 }

--- a/src/gui/gui_state.h
+++ b/src/gui/gui_state.h
@@ -19,6 +19,9 @@ typedef struct hasciicam_gui_state {
 
     unsigned int foreground_rgb;
     unsigned int background_rgb;
+    char font[64];
+    char active_font[64];
+    int font_change_requested;
 
     int capture_width;
     int capture_height;

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -56,6 +56,7 @@
 #include "output/output.h"
 #include "output/output_file.h"
 #include "render/render_session.h"
+#include "render/render_font.h"
 
 /* hasciicam modes */
 #define LIVE 0
@@ -145,6 +146,7 @@ main (int argc, char **argv) {
   int detected_screen_w = 0;
   int detected_screen_h = 0;
   int auto_live_size_applied = 0;
+  hasciicam_font_desc selected_font;
   char *device;
   char *aafile;
   char *background;
@@ -201,12 +203,19 @@ main (int argc, char **argv) {
   foreground = appcfg.foreground;
   fontface = appcfg.fontface;
   aadriver = appcfg.aadriver;
+  selected_font = hasciicam_font_find(appcfg.font);
+  if (selected_font.font == 0) {
+    fprintf(stderr, "!! unknown font '%s'\n", appcfg.font);
+    exit(1);
+  }
+  render_session.hwparams.font = selected_font.font;
   aa_geo.w = 80;
   aa_geo.h = 40;
   aa_geo.bright = appcfg.aa_bright;
   aa_geo.contrast = appcfg.aa_contrast;
   aa_geo.gamma = appcfg.aa_gamma;
   hasciicam_size_metrics_init(&size_metrics);
+  size_metrics.display_pixels_per_char_y = selected_font.height;
   hasciicam_size_build_plan(&appcfg, &size_metrics, &size_plan);
 
   if (mode == LIVE && !appcfg.explicit_size && !appcfg.explicit_aadriver) {
@@ -430,12 +439,19 @@ main (int argc, char **argv) {
       saved_path[sizeof(saved_path) - 1] = '\0';
       cfg_err[0] = '\0';
       if (hasciicam_config_load_toml(&appcfg, gui_state.load_path, cfg_err, sizeof(cfg_err))) {
+        char previous_font[64];
+        strncpy(previous_font, gui_state.active_font, sizeof(previous_font) - 1);
+        previous_font[sizeof(previous_font) - 1] = '\0';
         hasciicam_gui_state_init(&gui_state, &appcfg);
         strncpy(gui_state.load_path, loaded_path, sizeof(gui_state.load_path) - 1);
         gui_state.load_path[sizeof(gui_state.load_path) - 1] = '\0';
         strncpy(gui_state.save_path, saved_path, sizeof(gui_state.save_path) - 1);
         gui_state.save_path[sizeof(gui_state.save_path) - 1] = '\0';
         hasciicam_gui_state_set_capture_info(&gui_state, cap_info);
+        if (strcmp(previous_font, gui_state.font) != 0)
+          gui_state.font_change_requested = 1;
+        strncpy(gui_state.active_font, previous_font, sizeof(gui_state.active_font) - 1);
+        gui_state.active_font[sizeof(gui_state.active_font) - 1] = '\0';
         snprintf(gui_state.status_message, sizeof(gui_state.status_message),
                  "loaded: %s", loaded_path);
         gui_state.status_is_error = 0;
@@ -447,6 +463,17 @@ main (int argc, char **argv) {
     }
 
     hasciicam_live_controls_apply(&render_session, &session, &appcfg, &gui_state);
+    if (gui_state.font_change_requested) {
+      gui_state.font_change_requested = 0;
+      if (hasciicam_sdl_set_runtime_font(render_session.context, gui_state.font)) {
+        strncpy(gui_state.active_font, gui_state.font, sizeof(gui_state.active_font) - 1);
+        gui_state.active_font[sizeof(gui_state.active_font) - 1] = '\0';
+      } else {
+        snprintf(gui_state.status_message, sizeof(gui_state.status_message),
+                 "font change failed: %s", gui_state.font);
+        gui_state.status_is_error = 1;
+      }
+    }
     hasciicam_sdl_set_runtime_colors(render_session.context,
                                      gui_state.foreground_rgb,
                                      gui_state.background_rgb);

--- a/src/render/render_font.c
+++ b/src/render/render_font.c
@@ -1,0 +1,72 @@
+#include "render_font.h"
+
+#include <string.h>
+
+static hasciicam_font_desc font_desc_from_ptr(const struct aa_font *font) {
+    hasciicam_font_desc desc;
+    desc.short_name = 0;
+    desc.name = 0;
+    desc.height = 0;
+    desc.font = 0;
+    if (font == 0)
+        return desc;
+    desc.short_name = font->shortname;
+    desc.name = font->name;
+    desc.height = font->height;
+    desc.font = font;
+    return desc;
+}
+
+const char *hasciicam_font_default_name(void) {
+    return "vga16";
+}
+
+hasciicam_font_desc hasciicam_font_default(void) {
+    hasciicam_font_desc desc = hasciicam_font_find(hasciicam_font_default_name());
+    if (desc.font != 0)
+        return desc;
+    return font_desc_from_ptr(&aa_font16);
+}
+
+int hasciicam_font_count(void) {
+    int i;
+    for (i = 0; aa_fonts[i] != 0; i++) {
+    }
+    return i;
+}
+
+hasciicam_font_desc hasciicam_font_at(int index) {
+    int count = hasciicam_font_count();
+    if (index < 0 || index >= count)
+        return font_desc_from_ptr(0);
+    return font_desc_from_ptr(aa_fonts[index]);
+}
+
+hasciicam_font_desc hasciicam_font_find(const char *name_or_short_name) {
+    int i;
+    if (name_or_short_name == 0 || name_or_short_name[0] == '\0')
+        return font_desc_from_ptr(0);
+    for (i = 0; aa_fonts[i] != 0; i++) {
+        if ((aa_fonts[i]->shortname != 0 && strcmp(name_or_short_name, aa_fonts[i]->shortname) == 0) ||
+            (aa_fonts[i]->name != 0 && strcmp(name_or_short_name, aa_fonts[i]->name) == 0)) {
+            return font_desc_from_ptr(aa_fonts[i]);
+        }
+    }
+    return font_desc_from_ptr(0);
+}
+
+int hasciicam_font_write_list(FILE *stream) {
+    int i;
+    if (stream == 0)
+        return 0;
+    for (i = 0; aa_fonts[i] != 0; i++) {
+        const struct aa_font *font = aa_fonts[i];
+        if (fprintf(stream, "%s\t%s\t8x%d\n",
+                    font->shortname ? font->shortname : "",
+                    font->name ? font->name : "",
+                    font->height) < 0) {
+            return 0;
+        }
+    }
+    return 1;
+}

--- a/src/render/render_font.h
+++ b/src/render/render_font.h
@@ -5,6 +5,10 @@
 
 #include "../aalib/aalib.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct hasciicam_font_desc {
     const char *short_name;
     const char *name;
@@ -29,5 +33,9 @@ hasciicam_font_desc hasciicam_font_find(const char *name_or_short_name);
 
 /* Writes a stable font list to stream, one font per line; returns nonzero on success. */
 int hasciicam_font_write_list(FILE *stream);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/render/render_font.h
+++ b/src/render/render_font.h
@@ -1,0 +1,33 @@
+#ifndef HASCIICAM_RENDER_FONT_H
+#define HASCIICAM_RENDER_FONT_H
+
+#include <stdio.h>
+
+#include "../aalib/aalib.h"
+
+typedef struct hasciicam_font_desc {
+    const char *short_name;
+    const char *name;
+    int height;
+    const struct aa_font *font;
+} hasciicam_font_desc;
+
+/* Returns canonical default AA font short name used by HasciiCam config/UI. */
+const char *hasciicam_font_default_name(void);
+
+/* Returns descriptor for the canonical default AA font. */
+hasciicam_font_desc hasciicam_font_default(void);
+
+/* Returns number of AA fonts currently registered in aa_fonts[]. */
+int hasciicam_font_count(void);
+
+/* Returns descriptor for font at index, or zeroed descriptor on invalid index. */
+hasciicam_font_desc hasciicam_font_at(int index);
+
+/* Finds font by short name or long name; returns zeroed descriptor if not found. */
+hasciicam_font_desc hasciicam_font_find(const char *name_or_short_name);
+
+/* Writes a stable font list to stream, one font per line; returns nonzero on success. */
+int hasciicam_font_write_list(FILE *stream);
+
+#endif

--- a/tests/cli_config_startup.cmake
+++ b/tests/cli_config_startup.cmake
@@ -1,0 +1,35 @@
+if(NOT DEFINED HASCIICAM_EXE)
+  message(FATAL_ERROR "HASCIICAM_EXE is required")
+endif()
+if(NOT DEFINED HASCIICAM_OUTPUT_DIR)
+  message(FATAL_ERROR "HASCIICAM_OUTPUT_DIR is required")
+endif()
+
+set(_config_file "${HASCIICAM_OUTPUT_DIR}/cli-startup.toml")
+set(_output_file "${HASCIICAM_OUTPUT_DIR}/cli-config-startup.asc")
+set(_stderr_file "${HASCIICAM_OUTPUT_DIR}/cli-config-startup.err")
+
+file(REMOVE "${_config_file}" "${_output_file}" "${_stderr_file}")
+file(WRITE "${_config_file}" "mode = \"text\"\n")
+file(APPEND "${_config_file}" "output_file = \"${_output_file}\"\n")
+file(APPEND "${_config_file}" "device = \"synthetic://\"\n")
+file(APPEND "${_config_file}" "frames = 2\n")
+
+execute_process(
+  COMMAND "${HASCIICAM_EXE}" --config "${_config_file}"
+  RESULT_VARIABLE _rc
+  OUTPUT_VARIABLE _out
+  ERROR_FILE "${_stderr_file}"
+)
+if(NOT _rc EQUAL 0)
+  message(FATAL_ERROR "hasciicam --config exited with ${_rc}")
+endif()
+
+if(NOT EXISTS "${_output_file}")
+  message(FATAL_ERROR "configured output file not found: ${_output_file}")
+endif()
+file(READ "${_output_file}" _content)
+string(REGEX MATCH "[^ \t\r\n]" _nonws "${_content}")
+if(NOT _nonws)
+  message(FATAL_ERROR "configured output has no visible content")
+endif()

--- a/tests/cli_font_options.cmake
+++ b/tests/cli_font_options.cmake
@@ -1,0 +1,49 @@
+if(NOT DEFINED HASCIICAM_EXE)
+  message(FATAL_ERROR "HASCIICAM_EXE is required")
+endif()
+if(NOT DEFINED HASCIICAM_OUTPUT_DIR)
+  message(FATAL_ERROR "HASCIICAM_OUTPUT_DIR is required")
+endif()
+
+set(_list_file "${HASCIICAM_OUTPUT_DIR}/cli-font-list.out")
+set(_list_err "${HASCIICAM_OUTPUT_DIR}/cli-font-list.err")
+set(_text_out "${HASCIICAM_OUTPUT_DIR}/cli-font-vga8.asc")
+set(_text_err "${HASCIICAM_OUTPUT_DIR}/cli-font-vga8.err")
+file(REMOVE "${_list_file}" "${_list_err}" "${_text_out}" "${_text_err}")
+
+execute_process(
+  COMMAND "${HASCIICAM_EXE}" --font list
+  RESULT_VARIABLE _list_rc
+  OUTPUT_FILE "${_list_file}"
+  ERROR_FILE "${_list_err}"
+)
+if(NOT _list_rc EQUAL 0)
+  message(FATAL_ERROR "--font list exited with ${_list_rc}")
+endif()
+file(READ "${_list_file}" _list_text)
+string(FIND "${_list_text}" "vga16\t" _has_vga16)
+if(_has_vga16 EQUAL -1)
+  message(FATAL_ERROR "--font list output missing vga16")
+endif()
+string(FIND "${_list_text}" "courier\t" _has_courier)
+if(_has_courier EQUAL -1)
+  message(FATAL_ERROR "--font list output missing courier")
+endif()
+
+execute_process(
+  COMMAND "${HASCIICAM_EXE}" -d synthetic:// --frames 2 -m text --font vga8 -o "${_text_out}"
+  RESULT_VARIABLE _text_rc
+  OUTPUT_VARIABLE _text_stdout
+  ERROR_FILE "${_text_err}"
+)
+if(NOT _text_rc EQUAL 0)
+  message(FATAL_ERROR "--font vga8 text run exited with ${_text_rc}")
+endif()
+if(NOT EXISTS "${_text_out}")
+  message(FATAL_ERROR "expected output file not found: ${_text_out}")
+endif()
+file(READ "${_text_out}" _content)
+string(REGEX MATCH "[^ \t\r\n]" _nonws "${_content}")
+if(NOT _nonws)
+  message(FATAL_ERROR "font-selected output has no visible content")
+endif()

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -42,7 +42,7 @@ static void clear_test_env(void) {
     const char *keys[] = {
         "show_help", "show_aahelp", "show_version",
         "quiet", "mode", "device", "input", "size", "pixel_size", "char_size",
-        "output_file", "aa_driver", "daemon", "font_size", "font_face",
+        "output_file", "aa_driver", "daemon", "font_size", "font_face", "font",
         "refresh", "aa_bright", "aa_contrast", "aa_gamma", "invert",
         "background", "foreground", "uid", "gid", "frames",
         "sdl_renderer", "sdl_vsync", "fullscreen", "mirror"
@@ -61,6 +61,7 @@ static void test_env_load(void) {
     set_env_var("mode", "html");
     set_env_var("output_file", "env.html");
     set_env_var("font_size", "3");
+    set_env_var("font", "vga8");
     set_env_var("invert", "true");
     set_env_var("sdl_vsync", "off");
     set_env_var("char_size", "80x25");
@@ -70,6 +71,7 @@ static void test_env_load(void) {
     expect_true(cfg.mode == 1, "mode should be html");
     expect_true(strcmp(cfg.aafile, "env.html") == 0, "output_file should be env.html");
     expect_true(cfg.fontsize == 3, "font_size should be 3");
+    expect_true(strcmp(cfg.font, "vga8") == 0, "font should be vga8");
     expect_true(cfg.invert == 1, "invert should be true");
     expect_true(cfg.sdl_vsync == 0, "sdl_vsync should be off");
     expect_true(cfg.size_intent == HASCIICAM_SIZE_CHARS, "char_size should set char intent");
@@ -84,6 +86,7 @@ static void test_cli_overrides_env(void) {
         (char *)"hasciicam",
         (char *)"--mode", (char *)"text",
         (char *)"--font-size", (char *)"2",
+        (char *)"--font", (char *)"vga9",
         (char *)"-o", (char *)"cli.html"
     };
     int argc = (int)(sizeof(argv) / sizeof(argv[0]));
@@ -91,6 +94,7 @@ static void test_cli_overrides_env(void) {
     clear_test_env();
     set_env_var("mode", "html");
     set_env_var("font_size", "4");
+    set_env_var("font", "vga8");
     set_env_var("output_file", "env.html");
 
     hasciicam_config_init_defaults(&cfg);
@@ -99,6 +103,7 @@ static void test_cli_overrides_env(void) {
 
     expect_true(cfg.mode == 2, "cli mode should override env mode");
     expect_true(cfg.fontsize == 2, "cli font_size should override env font_size");
+    expect_true(strcmp(cfg.font, "vga9") == 0, "cli font should override env font");
     expect_true(strcmp(cfg.aafile, "cli.html") == 0, "cli output_file should override env output_file");
 
     clear_test_env();
@@ -117,6 +122,7 @@ static void test_default_toml_load(void) {
         fputs("mode = \"text\"\n", fp);
         fputs("output_file = \"default-config.asc\"\n", fp);
         fputs("aa_bright = 88\n", fp);
+        fputs("font = \"courier\"\n", fp);
         fclose(fp);
     }
 
@@ -129,6 +135,7 @@ static void test_default_toml_load(void) {
     expect_true(strcmp(cfg.aafile, "default-config.asc") == 0,
                 "default toml output_file should load");
     expect_true(cfg.aa_bright == 88, "default toml aa_bright should load");
+    expect_true(strcmp(cfg.font, "courier") == 0, "default toml font should load");
 
     remove(path);
     clear_test_env();
@@ -154,6 +161,7 @@ static void test_explicit_toml_precedence(void) {
 
     clear_test_env();
     set_env_var("font_size", "3");
+    set_env_var("font", "vga8");
     hasciicam_config_init_defaults(&cfg);
     optind = 1;
     hasciicam_config_parse(&cfg, argc, argv, "aahelp", "pkg", "1.0");
@@ -183,6 +191,7 @@ static void test_toml_roundtrip(void) {
     cfg.size_w = 90;
     cfg.size_h = 30;
     cfg.explicit_size = 1;
+    strcpy(cfg.font, "vga8");
 
     expect_true(hasciicam_config_save_toml(&cfg, path, err, sizeof(err)), "save_toml should succeed");
 
@@ -194,6 +203,7 @@ static void test_toml_roundtrip(void) {
     expect_true(loaded.invert == 1, "roundtrip invert should match");
     expect_true(loaded.size_intent == HASCIICAM_SIZE_CHARS, "roundtrip size intent should be chars");
     expect_true(loaded.size_w == 90 && loaded.size_h == 30, "roundtrip size should match");
+    expect_true(strcmp(loaded.font, "vga8") == 0, "roundtrip font should match");
 
     remove(path);
 }
@@ -211,6 +221,23 @@ static void test_toml_unknown_key(void) {
 
     hasciicam_config_init_defaults(&cfg);
     expect_true(!hasciicam_config_load_toml(&cfg, path, err, sizeof(err)), "load_toml should reject unknown key");
+    remove(path);
+}
+
+static void test_toml_invalid_font(void) {
+    hasciicam_config cfg;
+    char err[200];
+    const char *path = "test_app_config_bad_font.toml";
+    FILE *fp = fopen(path, "wb");
+    expect_true(fp != NULL, "should open bad font toml file");
+    if (fp) {
+        fputs("font = \"missing-font\"\n", fp);
+        fclose(fp);
+    }
+
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(!hasciicam_config_load_toml(&cfg, path, err, sizeof(err)),
+                "load_toml should reject invalid font");
     remove(path);
 }
 
@@ -267,6 +294,7 @@ int main(void) {
     test_explicit_toml_precedence();
     test_toml_roundtrip();
     test_toml_unknown_key();
+    test_toml_invalid_font();
     test_toml_mirror_roundtrip();
     test_toml_size_key_rejected();
     test_env_size_key_ignored();
@@ -277,3 +305,5 @@ int main(void) {
     }
     return 0;
 }
+
+

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -104,6 +104,69 @@ static void test_cli_overrides_env(void) {
     clear_test_env();
 }
 
+static void test_default_toml_load(void) {
+    hasciicam_config cfg;
+    char *argv[] = {
+        (char *)"hasciicam"
+    };
+    int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+    const char *path = "hasciicam.toml";
+    FILE *fp = fopen(path, "wb");
+    expect_true(fp != NULL, "should open default startup toml");
+    if (fp) {
+        fputs("mode = \"text\"\n", fp);
+        fputs("output_file = \"default-config.asc\"\n", fp);
+        fputs("aa_bright = 88\n", fp);
+        fclose(fp);
+    }
+
+    clear_test_env();
+    hasciicam_config_init_defaults(&cfg);
+    optind = 1;
+    hasciicam_config_parse(&cfg, argc, argv, "aahelp", "pkg", "1.0");
+
+    expect_true(cfg.mode == 2, "default toml mode should be text");
+    expect_true(strcmp(cfg.aafile, "default-config.asc") == 0,
+                "default toml output_file should load");
+    expect_true(cfg.aa_bright == 88, "default toml aa_bright should load");
+
+    remove(path);
+    clear_test_env();
+}
+
+static void test_explicit_toml_precedence(void) {
+    hasciicam_config cfg;
+    char *argv[] = {
+        (char *)"hasciicam",
+        (char *)"--config", (char *)"test_app_config_startup.toml",
+        (char *)"--mode", (char *)"text",
+        (char *)"-o", (char *)"cli.asc"
+    };
+    int argc = (int)(sizeof(argv) / sizeof(argv[0]));
+    FILE *fp = fopen("test_app_config_startup.toml", "wb");
+    expect_true(fp != NULL, "should open explicit startup toml");
+    if (fp) {
+        fputs("mode = \"html\"\n", fp);
+        fputs("output_file = \"toml.html\"\n", fp);
+        fputs("font_size = 4\n", fp);
+        fclose(fp);
+    }
+
+    clear_test_env();
+    set_env_var("font_size", "3");
+    hasciicam_config_init_defaults(&cfg);
+    optind = 1;
+    hasciicam_config_parse(&cfg, argc, argv, "aahelp", "pkg", "1.0");
+
+    expect_true(cfg.mode == 2, "cli mode should override explicit toml");
+    expect_true(strcmp(cfg.aafile, "cli.asc") == 0,
+                "cli output_file should override explicit toml");
+    expect_true(cfg.fontsize == 3, "env font_size should override explicit toml");
+
+    remove("test_app_config_startup.toml");
+    clear_test_env();
+}
+
 static void test_toml_roundtrip(void) {
     hasciicam_config cfg;
     hasciicam_config loaded;
@@ -200,6 +263,8 @@ static void test_env_size_key_ignored(void) {
 int main(void) {
     test_env_load();
     test_cli_overrides_env();
+    test_default_toml_load();
+    test_explicit_toml_precedence();
     test_toml_roundtrip();
     test_toml_unknown_key();
     test_toml_mirror_roundtrip();

--- a/tests/test_app_size.c
+++ b/tests/test_app_size.c
@@ -83,6 +83,26 @@ static int test_default_live_size_plan_small_display(void) {
            plan.requested_capture_height == 264;
 }
 
+static int test_pixel_size_plan_respects_font_height(void) {
+    hasciicam_config cfg;
+    hasciicam_size_metrics m;
+    hasciicam_size_plan plan_16;
+    hasciicam_size_plan plan_8;
+    memset(&cfg, 0, sizeof(cfg));
+    memset(&plan_16, 0, sizeof(plan_16));
+    memset(&plan_8, 0, sizeof(plan_8));
+    hasciicam_size_metrics_init(&m);
+    cfg.mode = LIVE;
+    cfg.size_intent = HASCIICAM_SIZE_PIXELS;
+    cfg.size_w = 1280;
+    cfg.size_h = 720;
+    hasciicam_size_build_plan(&cfg, &m, &plan_16);
+    m.display_pixels_per_char_y = 8;
+    hasciicam_size_build_plan(&cfg, &m, &plan_8);
+    return plan_8.preferred_ascii_height > plan_16.preferred_ascii_height &&
+           plan_8.requested_capture_height > plan_16.requested_capture_height;
+}
+
 int main(void) {
     if (!test_metrics_defaults()) return 1;
     if (!test_pixel_size_plan()) return 1;
@@ -90,6 +110,7 @@ int main(void) {
     if (!test_compute_ascii_from_capture()) return 1;
     if (!test_default_live_size_plan_hd()) return 1;
     if (!test_default_live_size_plan_small_display()) return 1;
+    if (!test_pixel_size_plan_respects_font_height()) return 1;
     printf("app_size tests passed\n");
     return 0;
 }

--- a/tests/test_gui_state.c
+++ b/tests/test_gui_state.c
@@ -25,6 +25,7 @@ int main(void) {
     cfg.invert = 1;
     cfg.mirror_x = 1;
     cfg.mirror_y = 0;
+    strcpy(cfg.font, "vga16");
 
     hasciicam_gui_state_init(&state, &cfg);
     if (!expect_true(state.aa_bright == 77, "bright init failed")) return 1;
@@ -34,6 +35,8 @@ int main(void) {
     if (!expect_true(state.mirror_x == 1 && state.mirror_y == 0, "mirror init failed")) return 1;
     if (!expect_true(state.background_rgb == 0x123456u, "background parse failed")) return 1;
     if (!expect_true(state.foreground_rgb == 0xABCDEFu, "foreground parse failed")) return 1;
+    if (!expect_true(strcmp(state.font, "vga16") == 0, "font init failed")) return 1;
+    if (!expect_true(strcmp(state.active_font, "vga16") == 0, "active font init failed")) return 1;
 
     if (!expect_true(hasciicam_gui_parse_rgb_hex("00ff11", &rgb) == 1, "rgb parse lower failed")) return 1;
     if (!expect_true(rgb == 0x00FF11u, "rgb parse value failed")) return 1;
@@ -50,6 +53,7 @@ int main(void) {
     state.mirror_y = 1;
     state.background_rgb = 0x0000FFu;
     state.foreground_rgb = 0xFF0000u;
+    strcpy(state.font, "vga8");
     hasciicam_gui_state_copy_to_config(&state, &cfg);
 
     if (!expect_true(cfg.aa_bright == 66, "bright copy failed")) return 1;
@@ -59,6 +63,7 @@ int main(void) {
     if (!expect_true(cfg.mirror_x == 0 && cfg.mirror_y == 1, "mirror copy failed")) return 1;
     if (!expect_true(strcmp(cfg.background, "0000FF") == 0, "background copy failed")) return 1;
     if (!expect_true(strcmp(cfg.foreground, "FF0000") == 0, "foreground copy failed")) return 1;
+    if (!expect_true(strcmp(cfg.font, "vga8") == 0, "font copy failed")) return 1;
 
     return 0;
 }

--- a/tests/test_render_font.c
+++ b/tests/test_render_font.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/render/render_font.h"
+
+static int failed = 0;
+
+static void expect_true(int cond, const char *msg) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        failed = 1;
+    }
+}
+
+int main(void) {
+    hasciicam_font_desc default_font;
+    hasciicam_font_desc vga16;
+    hasciicam_font_desc long_name;
+    hasciicam_font_desc missing;
+    FILE *fp;
+    char line[256];
+    int saw_vga16 = 0;
+    int saw_courier = 0;
+
+    expect_true(strcmp(hasciicam_font_default_name(), "vga16") == 0, "default font short name must be vga16");
+
+    default_font = hasciicam_font_default();
+    expect_true(default_font.font != 0, "default font must resolve");
+    expect_true(default_font.short_name != 0 && strcmp(default_font.short_name, "vga16") == 0,
+                "default descriptor short name must be vga16");
+
+    expect_true(hasciicam_font_count() >= 10, "expected bundled AA font catalog");
+
+    vga16 = hasciicam_font_find("vga16");
+    expect_true(vga16.font != 0, "must find vga16");
+    expect_true(vga16.height == 16, "vga16 height should be 16");
+
+    long_name = hasciicam_font_find("Standard vga 8x16 font");
+    expect_true(long_name.font != 0, "must find vga16 by long name");
+    expect_true(long_name.short_name != 0 && strcmp(long_name.short_name, "vga16") == 0,
+                "long-name lookup should resolve vga16");
+
+    missing = hasciicam_font_find("no-such-font");
+    expect_true(missing.font == 0, "unknown font should not resolve");
+
+    fp = fopen("test_render_font_list.txt", "wb");
+    expect_true(fp != 0, "must open temp file");
+    if (fp != 0) {
+        expect_true(hasciicam_font_write_list(fp) != 0, "font list writer should succeed");
+        fclose(fp);
+        fp = fopen("test_render_font_list.txt", "rb");
+        expect_true(fp != 0, "must reopen temp file");
+    }
+    if (fp != 0) {
+        while (fgets(line, (int)sizeof(line), fp) != 0) {
+            if (strstr(line, "vga16\t") == line)
+                saw_vga16 = 1;
+            if (strstr(line, "courier\t") == line)
+                saw_courier = 1;
+        }
+        fclose(fp);
+    }
+    remove("test_render_font_list.txt");
+
+    expect_true(saw_vga16, "font list should include vga16");
+    expect_true(saw_courier, "font list should include courier");
+
+    if (failed) {
+        return 1;
+    }
+    printf("render_font tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a shared AA font catalog API (`render_font`) for lookup/list/default handling
- add startup font selection across CLI/config/env (`--font <name>`, `--font list`, `font` key)
- apply selected font before render/session sizing so planning uses the selected cell height
- add live SDL GUI font combo + runtime font switch bridge
- keep color controls and GUI save/load behavior compatible while carrying font state
- update docs (`README`, `docs/hasciicam.1`, `AGENTS.md`)

## Test coverage
- new `render_font` unit test
- extended config/size/gui state tests for font behavior
- new CLI test `cli_font_options` covering `--font list` and `--font vga8`

## Validation
Built and tested with Windows vcpkg preset:
- `cmake --build --preset windows-vcpkg-ninja`
- `ctest --preset windows-vcpkg-ninja`
- Result: 21/21 tests passed

## Notes
- Scope remains bundled AA-lib bitmap fonts only (no external font loading).