### PR TITLE
Add live capture controls and pre-AA preview to SDL overlay

### DIFF
--- a/.gestalt/plans/capture-controls-preview.org
+++ b/.gestalt/plans/capture-controls-preview.org
@@ -34,14 +34,14 @@
 :Done when: The implementation avoids silently saving hardware-specific controls into the existing generic `hasciicam.toml`.
 :END:
 
-* TODO [#A] Implement backend control adapters incrementally
+* WIP [#A] Implement backend control adapters incrementally
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Surface real camera controls where practical, starting with the current Windows-first target while keeping Linux/macOS paths ready.
 :Notes: Do not add dependencies. Prefer OS APIs already available from current backend headers/libraries. Backends may support different subsets, and device drivers may report ranges differently.
 :END:
 
-** TODO [#A] Add DirectShow `IAMVideoProcAmp` and `IAMCameraControl` support
+** DONE [#A] Add DirectShow `IAMVideoProcAmp` and `IAMCameraControl` support
 :PROPERTIES:
 :Why: DirectShow exposes the common camera controls most directly on Windows fallback devices.
 :Change: In `src/capture/capture_dshow.cpp`, store `IAMVideoProcAmp *video_proc_amp` and `IAMCameraControl *camera_control` when available. Map `VideoProcAmp_Brightness`, `Contrast`, `Gamma`, `Gain`, `Saturation`, `Sharpness`, and `WhiteBalance` to capture controls. Map `CameraControl_Exposure`, `Focus`, and optionally `Zoom` if included. Use `GetRange()` for min/max/step/default/auto flags and `Get()` for current value/auto state. Use `Set()` to apply values, preserving auto/manual flags as appropriate.
@@ -73,14 +73,14 @@
 :Done when: macOS behavior is safe and does not show fake controls.
 :END:
 
-* TODO [#A] Add GUI state and live application for camera controls
+* DONE [#A] Add GUI state and live application for camera controls
 :PROPERTIES:
 :Effort: 0.75 day
 :Goal: Show OS/device capture controls in the existing right-click overlay and apply changes live when supported.
 :Notes: Keep the overlay dense and operational. If a backend reports no controls, show nothing or a single disabled "No camera controls" row; do not clutter the panel.
 :END:
 
-** TODO [#A] Extend GUI state with capture-control snapshots
+** DONE [#A] Extend GUI state with capture-control snapshots
 :PROPERTIES:
 :Why: The ImGui C++ layer should draw controls from plain state and set request flags; it should not know backend-specific APIs.
 :Change: Add a fixed-size array to `hasciicam_gui_state`, for example `capture_control_desc capture_controls[16]`, `capture_control_count`, and per-control dirty flags or a one-shot request field with changed ID/value. Add helper functions to load descriptors from an active `hasciicam_session` or capture wrapper. Keep size fixed to avoid GUI-time allocation.
@@ -88,7 +88,7 @@
 :Done when: GUI state can represent supported camera controls independently of SDL/ImGui.
 :END:
 
-** TODO [#A] Render a "Camera Controls" section in the overlay
+** DONE [#A] Render a "Camera Controls" section in the overlay
 :PROPERTIES:
 :Why: Users need sliders for camera-side values, separate from AA render sliders.
 :Change: In `src/gui/gui_overlay.cpp`, add a section after "Capture" or before "AA Rendering" named "Camera Controls". For each writable integer control, draw a slider using min/max and step if ImGui supports it cleanly; otherwise use `SliderInt`. For read-only controls, draw label/value disabled. If auto is supported, draw a checkbox next to the control or just above it. When a value changes, set the GUI state's change request; avoid sending a backend call every frame if the value did not change.
@@ -96,7 +96,7 @@
 :Done when: Overlay can display and request capture-control changes without direct backend coupling.
 :END:
 
-** TODO [#A] Apply capture-control changes from the app loop
+** DONE [#A] Apply capture-control changes from the app loop
 :PROPERTIES:
 :Why: Backend calls should happen in the C app/session layer, not in the overlay renderer.
 :Change: In `src/hasciicam.c` or a small `src/app/app_capture_controls.c`, after GUI events are processed and before reading the next frame, consume pending control requests from `gui_state`, call the capture-control wrapper on the active session, refresh the descriptor current value, and update `status_message` on failure. Ensure failed changes do not stop capture.

--- a/.gestalt/plans/capture-controls-preview.org
+++ b/.gestalt/plans/capture-controls-preview.org
@@ -34,7 +34,7 @@
 :Done when: The implementation avoids silently saving hardware-specific controls into the existing generic `hasciicam.toml`.
 :END:
 
-* WIP [#A] Implement backend control adapters incrementally
+* DONE [#A] Implement backend control adapters incrementally
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Surface real camera controls where practical, starting with the current Windows-first target while keeping Linux/macOS paths ready.
@@ -49,7 +49,7 @@
 :Done when: DirectShow devices with supported controls expose correct metadata and accept runtime changes without breaking frame capture.
 :END:
 
-** TODO [#B] Investigate Media Foundation control support before implementing
+** DONE [#B] Investigate Media Foundation control support before implementing
 :PROPERTIES:
 :Why: Media Foundation capture in this repo currently uses `IMFSourceReader`; camera controls are not as uniformly exposed through that path.
 :Change: Check whether the active `IMFMediaSource` can expose `IKsControl`, `IAMVideoProcAmp`, or a related control interface for the selected device on Windows. If it is straightforward, implement the same `capture_ops` functions in `src/capture/capture_mf.c`. If it requires substantial device-activation or KS property plumbing, document MF as "controls unavailable" for this slice and rely on DirectShow fallback for Windows camera-control support.
@@ -57,7 +57,7 @@
 :Done when: MF behavior is explicit: either supported through the same port or intentionally returns no controls with no GUI breakage.
 :END:
 
-** TODO [#B] Add V4L2 control mapping
+** DONE [#B] Add V4L2 control mapping
 :PROPERTIES:
 :Why: Linux commonly exposes camera controls through V4L2 CIDs.
 :Change: In `src/capture/capture_v4l2.c`, query supported controls with `VIDIOC_QUERYCTRL`/`VIDIOC_QUERY_EXT_CTRL` where available and current values with `VIDIOC_G_CTRL`. Map common CIDs: `V4L2_CID_BRIGHTNESS`, `CONTRAST`, `GAMMA`, `GAIN`, `SATURATION`, `SHARPNESS`, `EXPOSURE_ABSOLUTE`, `AUTO_EXPOSURE` where applicable, `WHITE_BALANCE_TEMPERATURE`, `AUTO_WHITE_BALANCE`, and focus controls if present. Hide disabled/inactive controls. Set values through `VIDIOC_S_CTRL`.
@@ -65,7 +65,7 @@
 :Done when: V4L2 can expose common controls without requiring a camera for automated tests.
 :END:
 
-** TODO [#C] Leave AVFoundation as capability-aware follow-up unless needed
+** DONE [#C] Leave AVFoundation as capability-aware follow-up unless needed
 :PROPERTIES:
 :Why: macOS camera controls differ from brightness/contrast/gamma and often require device locking plus hardware-specific availability checks.
 :Change: In `src/capture/capture_avfoundation.mm`, return zero controls initially or expose only safe controls that are clearly available through `AVCaptureDevice` (`exposure`, `focus`, `white_balance`) if implementation remains small. Avoid pretending brightness/contrast/gamma are OS camera controls on macOS when they would really be post-processing.
@@ -143,14 +143,14 @@
 :Done when: Preview updates continuously without repeated allocations in the steady state.
 :END:
 
-* WIP [#B] Verify, document, and update the plan status
+* DONE [#B] Verify, document, and update the plan status
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Keep the feature discoverable and leave a clear test trail across Windows-first and portable backends.
 :Notes: This is a user-facing GUI feature and a backend capability feature. Documentation should make clear that camera controls are device-dependent.
 :END:
 
-** TODO [#A] Add focused automated tests
+** DONE [#A] Add focused automated tests
 :PROPERTIES:
 :Why: The most important logic can be tested without a camera: control wrappers, GUI state requests, and grayscale preview copying.
 :Change: Add or extend plain C tests for capture-control wrapper behavior, GUI state control requests, and preview buffer copying/resizing. Add CTest entries. Keep real camera tests opt-in/manual.
@@ -174,7 +174,7 @@
 :Done when: The feature builds, automated tests pass, and manual validation notes are recorded.
 :END:
 
-** TODO [#C] Keep follow-up scope explicit
+** DONE [#C] Keep follow-up scope explicit
 :PROPERTIES:
 :Why: Camera controls can grow into per-device profiles, image post-processing, and platform-specific tuning UIs.
 :Change: Do not add persisted camera profiles, software post-processing brightness/contrast/gamma, native camera property dialogs, or external dependencies in this slice. If MF/AVFoundation control support is not small, document it as follow-up rather than blocking DirectShow/V4L2 and preview work.

--- a/.gestalt/plans/capture-controls-preview.org
+++ b/.gestalt/plans/capture-controls-preview.org
@@ -1,0 +1,183 @@
+#+TITLE: Capture Controls Preview
+#+SUBTITLE: Add optional OS camera controls and an opaque grayscale pre-AA preview to the SDL overlay
+#+DATE: 2026-06-01
+#+KEYWORDS: capture controls gui sdl preview grayscale v4l2 directshow mediafoundation avfoundation
+
+* WIP [#A] Define a minimal capture-control port
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Expose camera-side tweakable controls through the capture abstraction without mixing them with AA-lib render controls.
+:Notes: Challenge the first idea of adding backend-specific sliders directly in the GUI. Brightness/contrast/gamma in AA-lib are renderer controls; camera brightness/contrast/gamma are device controls and may not exist on every backend/device. Use a small optional capture port with queryable metadata so the GUI only shows supported controls.
+:END:
+
+** DONE [#A] Add portable control descriptors to `capture.h`
+:PROPERTIES:
+:Why: The GUI needs to know which camera controls exist, their ranges, defaults, current values, and whether they are writable before drawing sliders.
+:Change: Add `capture_control_id`, `capture_control_kind`, and `capture_control_desc` in `src/capture/capture.h`. Include IDs for `brightness`, `contrast`, `gamma`, `gain`, `saturation`, `sharpness`, `exposure`, `white_balance`, and `focus`. Keep fields plain: stable name, label, min, max, step, default, current, writable, auto_supported, auto_enabled. Avoid floats at the capture boundary; OS APIs generally expose integer ranges.
+:Tests: Add a compile/link unit test that initializes descriptors and verifies enum/string helpers if implemented. Existing capture backends must still compile with zero controls.
+:Done when: Capture control metadata can be represented without any backend-specific headers leaking outside `src/capture`.
+:END:
+
+** DONE [#A] Extend `capture_ops` with optional control functions
+:PROPERTIES:
+:Why: Existing backends should continue to work, while capable backends can report and apply controls.
+:Change: Add optional function pointers to `capture_ops`: `list_controls(capture_device *, capture_control_desc *, int max_controls)`, `set_control(capture_device *, capture_control_id, int value)`, and optionally `set_control_auto(capture_device *, capture_control_id, int enabled)`. Treat NULL pointers as "no controls". Add small wrapper helpers, likely in `src/capture/capture_control.c`, so application code calls `capture_controls_list(...)` and `capture_control_set(...)` instead of checking function pointers everywhere.
+:Tests: Add a fake/test capture ops instance to verify wrapper behavior for NULL ops, zero controls, successful set, and failed set. Existing synthetic capture should report no controls unless explicitly extended for tests.
+:Done when: The application can safely ask any active backend for controls and apply changes without knowing backend type.
+:END:
+
+** TODO [#B] Decide canonical control names and config scope
+:PROPERTIES:
+:Why: Some device controls are runtime-only and hardware-specific; persisting them can fail on another camera or OS.
+:Change: Keep capture controls runtime-only in the first implementation. Do not add TOML/CLI persistence until the backend API is proven. Name GUI sections clearly: "Camera Controls" for OS/device controls and "AA Rendering" for renderer controls. If later persistence is needed, create a separate plan for per-device profiles.
+:Tests: No code test if this only documents/structures scope.
+:Done when: The implementation avoids silently saving hardware-specific controls into the existing generic `hasciicam.toml`.
+:END:
+
+* TODO [#A] Implement backend control adapters incrementally
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Surface real camera controls where practical, starting with the current Windows-first target while keeping Linux/macOS paths ready.
+:Notes: Do not add dependencies. Prefer OS APIs already available from current backend headers/libraries. Backends may support different subsets, and device drivers may report ranges differently.
+:END:
+
+** TODO [#A] Add DirectShow `IAMVideoProcAmp` and `IAMCameraControl` support
+:PROPERTIES:
+:Why: DirectShow exposes the common camera controls most directly on Windows fallback devices.
+:Change: In `src/capture/capture_dshow.cpp`, store `IAMVideoProcAmp *video_proc_amp` and `IAMCameraControl *camera_control` when available. Map `VideoProcAmp_Brightness`, `Contrast`, `Gamma`, `Gain`, `Saturation`, `Sharpness`, and `WhiteBalance` to capture controls. Map `CameraControl_Exposure`, `Focus`, and optionally `Zoom` if included. Use `GetRange()` for min/max/step/default/auto flags and `Get()` for current value/auto state. Use `Set()` to apply values, preserving auto/manual flags as appropriate.
+:Tests: Add compile-time coverage through Windows build. Add unit-level mapping helper tests if mappings are factored into pure functions. Manual test on a Windows camera: confirm supported controls appear and moving sliders changes the camera feed before AA rendering.
+:Done when: DirectShow devices with supported controls expose correct metadata and accept runtime changes without breaking frame capture.
+:END:
+
+** TODO [#B] Investigate Media Foundation control support before implementing
+:PROPERTIES:
+:Why: Media Foundation capture in this repo currently uses `IMFSourceReader`; camera controls are not as uniformly exposed through that path.
+:Change: Check whether the active `IMFMediaSource` can expose `IKsControl`, `IAMVideoProcAmp`, or a related control interface for the selected device on Windows. If it is straightforward, implement the same `capture_ops` functions in `src/capture/capture_mf.c`. If it requires substantial device-activation or KS property plumbing, document MF as "controls unavailable" for this slice and rely on DirectShow fallback for Windows camera-control support.
+:Tests: Build on Windows. If implemented, manually test on a real camera. If not implemented, verify MF backend reports zero controls and GUI hides the section.
+:Done when: MF behavior is explicit: either supported through the same port or intentionally returns no controls with no GUI breakage.
+:END:
+
+** TODO [#B] Add V4L2 control mapping
+:PROPERTIES:
+:Why: Linux commonly exposes camera controls through V4L2 CIDs.
+:Change: In `src/capture/capture_v4l2.c`, query supported controls with `VIDIOC_QUERYCTRL`/`VIDIOC_QUERY_EXT_CTRL` where available and current values with `VIDIOC_G_CTRL`. Map common CIDs: `V4L2_CID_BRIGHTNESS`, `CONTRAST`, `GAMMA`, `GAIN`, `SATURATION`, `SHARPNESS`, `EXPOSURE_ABSOLUTE`, `AUTO_EXPOSURE` where applicable, `WHITE_BALANCE_TEMPERATURE`, `AUTO_WHITE_BALANCE`, and focus controls if present. Hide disabled/inactive controls. Set values through `VIDIOC_S_CTRL`.
+:Tests: Compile on Linux preset when available. Unit-test mapping helpers where possible. Manual Linux smoke with a V4L2 camera: list controls and adjust one visible slider.
+:Done when: V4L2 can expose common controls without requiring a camera for automated tests.
+:END:
+
+** TODO [#C] Leave AVFoundation as capability-aware follow-up unless needed
+:PROPERTIES:
+:Why: macOS camera controls differ from brightness/contrast/gamma and often require device locking plus hardware-specific availability checks.
+:Change: In `src/capture/capture_avfoundation.mm`, return zero controls initially or expose only safe controls that are clearly available through `AVCaptureDevice` (`exposure`, `focus`, `white_balance`) if implementation remains small. Avoid pretending brightness/contrast/gamma are OS camera controls on macOS when they would really be post-processing.
+:Tests: macOS build when available. Manual AVFoundation check only if controls are implemented.
+:Done when: macOS behavior is safe and does not show fake controls.
+:END:
+
+* TODO [#A] Add GUI state and live application for camera controls
+:PROPERTIES:
+:Effort: 0.75 day
+:Goal: Show OS/device capture controls in the existing right-click overlay and apply changes live when supported.
+:Notes: Keep the overlay dense and operational. If a backend reports no controls, show nothing or a single disabled "No camera controls" row; do not clutter the panel.
+:END:
+
+** TODO [#A] Extend GUI state with capture-control snapshots
+:PROPERTIES:
+:Why: The ImGui C++ layer should draw controls from plain state and set request flags; it should not know backend-specific APIs.
+:Change: Add a fixed-size array to `hasciicam_gui_state`, for example `capture_control_desc capture_controls[16]`, `capture_control_count`, and per-control dirty flags or a one-shot request field with changed ID/value. Add helper functions to load descriptors from an active `hasciicam_session` or capture wrapper. Keep size fixed to avoid GUI-time allocation.
+:Tests: Extend `tests/test_gui_state.c` to verify controls initialize empty, descriptors copy correctly, and dirty/request flags are set/cleared predictably.
+:Done when: GUI state can represent supported camera controls independently of SDL/ImGui.
+:END:
+
+** TODO [#A] Render a "Camera Controls" section in the overlay
+:PROPERTIES:
+:Why: Users need sliders for camera-side values, separate from AA render sliders.
+:Change: In `src/gui/gui_overlay.cpp`, add a section after "Capture" or before "AA Rendering" named "Camera Controls". For each writable integer control, draw a slider using min/max and step if ImGui supports it cleanly; otherwise use `SliderInt`. For read-only controls, draw label/value disabled. If auto is supported, draw a checkbox next to the control or just above it. When a value changes, set the GUI state's change request; avoid sending a backend call every frame if the value did not change.
+:Tests: Build GUI. Unit-test state-level request behavior. Manual overlay test with fake/no controls should not crash; with a real DirectShow/V4L2 camera, sliders should appear only for supported controls.
+:Done when: Overlay can display and request capture-control changes without direct backend coupling.
+:END:
+
+** TODO [#A] Apply capture-control changes from the app loop
+:PROPERTIES:
+:Why: Backend calls should happen in the C app/session layer, not in the overlay renderer.
+:Change: In `src/hasciicam.c` or a small `src/app/app_capture_controls.c`, after GUI events are processed and before reading the next frame, consume pending control requests from `gui_state`, call the capture-control wrapper on the active session, refresh the descriptor current value, and update `status_message` on failure. Ensure failed changes do not stop capture.
+:Tests: Add wrapper tests with fake ops. Manual camera test: moving a slider affects the next captured frames and error status is visible for rejected values.
+:Done when: Camera-control changes apply live and safely from the main loop.
+:END:
+
+* WIP [#A] Add an opaque grayscale pre-AA preview to the SDL overlay
+:PROPERTIES:
+:Effort: 1 day
+:Goal: Show a small scaled preview of the luminance buffer exactly after capture conversion/mirroring and immediately before AA-lib consumes it.
+:Notes: This preview is diagnostic: it should show the grayscale image that goes into AA-lib, not the raw camera frame and not the final ASCII result. It must be 100% opaque even though the overlay window itself currently uses alpha.
+:END:
+
+** DONE [#A] Store latest pre-AA grayscale frame in GUI state
+:PROPERTIES:
+:Why: The render loop already receives `gray_frame` from `hasciicam_session_step()` before copying to `aa_image()`. The overlay needs a stable snapshot because the session buffer can be reallocated on resize/font changes.
+:Change: Add preview fields to `hasciicam_gui_state`: `preview_width`, `preview_height`, `preview_stride`, `preview_generation`, a fixed upper bound or heap buffer pointer for grayscale pixels, and capacity. Prefer a small helper `hasciicam_gui_state_update_preview(state, gray_frame, width, height)` that copies the grayscale frame after `hasciicam_session_step()` succeeds and before `memcpy(aa_image(...))`. If heap allocation is added, make ownership explicit with init/reset/free helpers.
+:Tests: Extend `test_gui_state.c` to update preview with a small grayscale pattern, verify dimensions/copy/generation, and verify resize reallocates or rejects safely.
+:Done when: GUI state owns the latest pre-AA luminance snapshot and survives output-size changes.
+:END:
+
+** DONE [#A] Upload preview pixels to an SDL/ImGui texture
+:PROPERTIES:
+:Why: ImGui needs a texture ID, not a raw grayscale pointer, and the texture must update when dimensions or generation change.
+:Change: In the SDL GUI implementation, add preview texture state near the overlay or SDL driver GUI state. Convert GRAY8 to an opaque RGBA/RGB texture with `alpha = 255` for every pixel. Use nearest-neighbor scaling in ImGui by drawing `ImGui::Image()` at a small size, preserving aspect ratio. Recreate the texture if preview dimensions change. Destroy it on GUI shutdown.
+:Tests: Build with SDL/GUI. Add a manual SDL synthetic smoke: open overlay and confirm the preview is visible, grayscale, opaque, and not tinted by foreground/background controls.
+:Done when: The preview renders from the latest luminance buffer and every preview pixel is uploaded with full opacity.
+:END:
+
+** DONE [#B] Place preview in the overlay without crowding controls
+:PROPERTIES:
+:Why: The panel is already dense. The preview should help tuning without pushing primary controls off-screen.
+:Change: Add a "Pre-AA Preview" block near the top or under "Capture". Use a width capped around 160-220 px and compute height from aspect ratio. Use a dark border or label only if needed; avoid nested cards. If no frame has arrived yet, draw a small disabled text row such as "No preview yet".
+:Tests: Manual visual smoke with `synthetic://` in SDL live mode. Resize the overlay/window and confirm no clipping or overlap.
+:Done when: The overlay includes a small usable preview and still fits common Windows display sizes.
+:END:
+
+** TODO [#B] Keep preview updates cheap
+:PROPERTIES:
+:Why: The preview should not dominate frame time or allocate every frame.
+:Change: Reuse the GUI preview buffer and SDL texture between frames. Only recreate on dimension change. If the AA image is large, optionally downsample while copying to a max preview texture size, but keep the source semantics documented: it is sampled from the exact pre-AA grayscale buffer. Start simple; add downsampling only if profiling shows noticeable cost.
+:Tests: Manual SDL run for several seconds with overlay open. Confirm no visible stalls and no unbounded memory growth.
+:Done when: Preview updates continuously without repeated allocations in the steady state.
+:END:
+
+* TODO [#B] Verify, document, and update the plan status
+:PROPERTIES:
+:Effort: 0.5 day
+:Goal: Keep the feature discoverable and leave a clear test trail across Windows-first and portable backends.
+:Notes: This is a user-facing GUI feature and a backend capability feature. Documentation should make clear that camera controls are device-dependent.
+:END:
+
+** TODO [#A] Add focused automated tests
+:PROPERTIES:
+:Why: The most important logic can be tested without a camera: control wrappers, GUI state requests, and grayscale preview copying.
+:Change: Add or extend plain C tests for capture-control wrapper behavior, GUI state control requests, and preview buffer copying/resizing. Add CTest entries. Keep real camera tests opt-in/manual.
+:Tests: Run touched tests after each L2, then full CTest on Windows vcpkg preset at the end.
+:Done when: Core state/control logic is covered without requiring a camera or window.
+:END:
+
+** TODO [#B] Document camera-control behavior and limitations
+:PROPERTIES:
+:Why: Users need to understand why controls appear on one camera/OS but not another.
+:Change: Update `README.md`, `docs/hasciicam.1`, and `AGENTS.md`. Describe "Camera Controls" as OS/device controls, separate from "AA Rendering". Note that supported sliders are backend/device-dependent and may include brightness/contrast/gamma/gain/exposure/focus/white balance. Document that the pre-AA preview shows the grayscale luminance frame after capture conversion/mirroring and before AA-lib rendering.
+:Tests: Existing help/doc tests if any. Manual review for terminology consistency.
+:Done when: Documentation avoids promising universal controls and clearly explains the preview.
+:END:
+
+** TODO [#A] Run Windows-first validation
+:PROPERTIES:
+:Why: Windows is the current target and DirectShow/SDL are the likely first working control/preview path.
+:Change: Run `cmake --preset windows-vcpkg-ninja`, `cmake --build --preset windows-vcpkg-ninja`, and `ctest --preset windows-vcpkg-ninja` from a `vcvarsall.bat` environment. Then manually run `hasciicam -q -d synthetic:// -O SDL --frames 2` for no-camera GUI safety and an interactive camera run where the overlay preview and any exposed camera controls are exercised.
+:Tests: Full CTest plus manual SDL smoke. If a real camera is unavailable, state that only synthetic/no-control GUI behavior was manually verified.
+:Done when: The feature builds, automated tests pass, and manual validation notes are recorded.
+:END:
+
+** TODO [#C] Keep follow-up scope explicit
+:PROPERTIES:
+:Why: Camera controls can grow into per-device profiles, image post-processing, and platform-specific tuning UIs.
+:Change: Do not add persisted camera profiles, software post-processing brightness/contrast/gamma, native camera property dialogs, or external dependencies in this slice. If MF/AVFoundation control support is not small, document it as follow-up rather than blocking DirectShow/V4L2 and preview work.
+:Tests: No code tests.
+:Done when: The first implementation remains limited to optional backend-reported controls and the pre-AA grayscale preview.
+:END:

--- a/.gestalt/plans/capture-controls-preview.org
+++ b/.gestalt/plans/capture-controls-preview.org
@@ -3,7 +3,7 @@
 #+DATE: 2026-06-01
 #+KEYWORDS: capture controls gui sdl preview grayscale v4l2 directshow mediafoundation avfoundation
 
-* WIP [#A] Define a minimal capture-control port
+* DONE [#A] Define a minimal capture-control port
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Expose camera-side tweakable controls through the capture abstraction without mixing them with AA-lib render controls.
@@ -26,7 +26,7 @@
 :Done when: The application can safely ask any active backend for controls and apply changes without knowing backend type.
 :END:
 
-** TODO [#B] Decide canonical control names and config scope
+** DONE [#B] Decide canonical control names and config scope
 :PROPERTIES:
 :Why: Some device controls are runtime-only and hardware-specific; persisting them can fail on another camera or OS.
 :Change: Keep capture controls runtime-only in the first implementation. Do not add TOML/CLI persistence until the backend API is proven. Name GUI sections clearly: "Camera Controls" for OS/device controls and "AA Rendering" for renderer controls. If later persistence is needed, create a separate plan for per-device profiles.
@@ -104,7 +104,7 @@
 :Done when: Camera-control changes apply live and safely from the main loop.
 :END:
 
-* WIP [#A] Add an opaque grayscale pre-AA preview to the SDL overlay
+* DONE [#A] Add an opaque grayscale pre-AA preview to the SDL overlay
 :PROPERTIES:
 :Effort: 1 day
 :Goal: Show a small scaled preview of the luminance buffer exactly after capture conversion/mirroring and immediately before AA-lib consumes it.
@@ -135,7 +135,7 @@
 :Done when: The overlay includes a small usable preview and still fits common Windows display sizes.
 :END:
 
-** TODO [#B] Keep preview updates cheap
+** DONE [#B] Keep preview updates cheap
 :PROPERTIES:
 :Why: The preview should not dominate frame time or allocate every frame.
 :Change: Reuse the GUI preview buffer and SDL texture between frames. Only recreate on dimension change. If the AA image is large, optionally downsample while copying to a max preview texture size, but keep the source semantics documented: it is sampled from the exact pre-AA grayscale buffer. Start simple; add downsampling only if profiling shows noticeable cost.
@@ -143,7 +143,7 @@
 :Done when: Preview updates continuously without repeated allocations in the steady state.
 :END:
 
-* TODO [#B] Verify, document, and update the plan status
+* WIP [#B] Verify, document, and update the plan status
 :PROPERTIES:
 :Effort: 0.5 day
 :Goal: Keep the feature discoverable and leave a clear test trail across Windows-first and portable backends.
@@ -158,7 +158,7 @@
 :Done when: Core state/control logic is covered without requiring a camera or window.
 :END:
 
-** TODO [#B] Document camera-control behavior and limitations
+** DONE [#B] Document camera-control behavior and limitations
 :PROPERTIES:
 :Why: Users need to understand why controls appear on one camera/OS but not another.
 :Change: Update `README.md`, `docs/hasciicam.1`, and `AGENTS.md`. Describe "Camera Controls" as OS/device controls, separate from "AA Rendering". Note that supported sliders are backend/device-dependent and may include brightness/contrast/gamma/gain/exposure/focus/white balance. Document that the pre-AA preview shows the grayscale luminance frame after capture conversion/mirroring and before AA-lib rendering.
@@ -166,7 +166,7 @@
 :Done when: Documentation avoids promising universal controls and clearly explains the preview.
 :END:
 
-** TODO [#A] Run Windows-first validation
+** DONE [#A] Run Windows-first validation
 :PROPERTIES:
 :Why: Windows is the current target and DirectShow/SDL are the likely first working control/preview path.
 :Change: Run `cmake --preset windows-vcpkg-ninja`, `cmake --build --preset windows-vcpkg-ninja`, and `ctest --preset windows-vcpkg-ninja` from a `vcvarsall.bat` environment. Then manually run `hasciicam -q -d synthetic:// -O SDL --frames 2` for no-camera GUI safety and an interactive camera run where the overlay preview and any exposed camera controls are exercised.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,7 @@ Capture is now behind a small C port in `src/capture/capture.h`:
 - response: actual width, height, stride, and pixel format.
 - operations: open, start, read/dequeue one frame, release/requeue frame, stop,
   close.
+- optional control hooks: list/set camera controls (backend/device dependent).
 
 Current adapters:
 
@@ -360,6 +361,18 @@ In `TEXT` mode:
 
 The save driver writes from AA-lib `textbuffer` and `attrbuffer`, so file output
 and live output share the same render stage.
+
+## SDL GUI Notes
+
+In SDL live mode, the right-click overlay can show:
+
+- AA rendering controls (renderer-side brightness/contrast/gamma/invert)
+- camera controls exposed by the active capture backend/device
+- a small pre-AA grayscale preview of the luminance frame that is copied into
+  `aa_image(...)` before rendering
+
+Camera controls are optional and backend/device dependent. Do not assume they
+exist on every platform or every camera.
 
 ## TOML Config API
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,14 @@ if(HASCIICAM_ENABLE_TESTS)
   add_test(NAME capture_size COMMAND test_capture_size)
   set_tests_properties(capture_size PROPERTIES LABELS "unit;core")
 
+  add_executable(test_capture_control
+    tests/test_capture_control.c
+    src/capture/capture_control.c
+  )
+  target_include_directories(test_capture_control PRIVATE src/capture)
+  add_test(NAME capture_control COMMAND test_capture_control)
+  set_tests_properties(capture_control PROPERTIES LABELS "unit;core")
+
   add_executable(test_core_link tests/test_core_link.c)
   target_include_directories(test_core_link PRIVATE include)
   target_link_libraries(test_core_link PRIVATE hasciicam_core)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ HasciiCam can show an optional on-screen control panel in live SDL mode.
 - Build toggle: `HASCIICAM_ENABLE_GUI` (requires SDL and vendored Dear ImGui under `third_party/imgui/`)
 - Activation: right mouse click in the SDL window
 - Live controls: AA brightness/contrast/gamma, invert, mirror, foreground/background colors, AA font
+- Camera controls: device/driver-dependent controls (when backend reports them), e.g. brightness/contrast/gamma/exposure/focus
+- Pre-AA preview: small opaque grayscale preview of the luminance frame right before AA-lib rendering
 - Config actions: `Save` writes TOML, `Load` reads TOML
 
 File chooser behavior:

--- a/cmake/HasciiCamSources.cmake
+++ b/cmake/HasciiCamSources.cmake
@@ -73,6 +73,7 @@ set(HASCIICAM_RENDER_SOURCES
 
 set(HASCIICAM_CAPTURE_SOURCES
     src/capture/capture_backend.c
+    src/capture/capture_control.c
     src/capture/capture_external.c
     src/capture/capture_size.c
     src/capture/capture_synthetic.c

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -179,6 +179,10 @@ sdl_vsync = "off"
 .fi
 .SH NOTES
 When using a usb webcam, a supported size needs to be specified. The minimum or maximum detected size should work, also a size of 160x120 mostly gives good results, with unsupported sizes you will get unexpected results.
+.IP
+In SDL live mode, the right-click GUI can expose camera controls when the active capture backend and camera driver support them. Available controls are device-dependent.
+.IP
+The SDL GUI also shows a small pre-AA preview: the grayscale luminance frame after capture conversion/mirroring and immediately before AA-lib consumes it.
 .SH BUGS
 Report bugs to hasciicam@dyne.org. Please include a complete, self-contained example that will allow the bug to be reproduced, information about which version of hasciicam you are using, which operative system and the complete device detection output.
 .SH AUTHOR

--- a/src/app/app_session.c
+++ b/src/app/app_session.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "../capture/capture_backend.h"
+#include "../capture/capture_control.h"
 #include "../capture/capture_external.h"
 #include "../capture/frame_convert.h"
 
@@ -120,4 +121,28 @@ int hasciicam_session_should_stop(const hasciicam_session *session) {
     if (session == NULL)
         return 1;
     return session->stop_requested;
+}
+
+int hasciicam_session_list_controls(hasciicam_session *session,
+                                    capture_control_desc *out,
+                                    int max_controls) {
+    if (session == NULL)
+        return 0;
+    return capture_controls_list(session->capture_dev, session->capture_ops, out, max_controls);
+}
+
+int hasciicam_session_set_control(hasciicam_session *session,
+                                  capture_control_id id,
+                                  int value) {
+    if (session == NULL)
+        return 0;
+    return capture_control_set(session->capture_dev, session->capture_ops, id, value);
+}
+
+int hasciicam_session_set_control_auto(hasciicam_session *session,
+                                       capture_control_id id,
+                                       int enabled) {
+    if (session == NULL)
+        return 0;
+    return capture_control_set_auto(session->capture_dev, session->capture_ops, id, enabled);
 }

--- a/src/app/app_session.h
+++ b/src/app/app_session.h
@@ -31,5 +31,14 @@ void hasciicam_session_stop(hasciicam_session *session);
 const capture_info *hasciicam_session_capture_info(const hasciicam_session *session);
 void hasciicam_session_request_stop(hasciicam_session *session);
 int hasciicam_session_should_stop(const hasciicam_session *session);
+int hasciicam_session_list_controls(hasciicam_session *session,
+                                    capture_control_desc *out,
+                                    int max_controls);
+int hasciicam_session_set_control(hasciicam_session *session,
+                                  capture_control_id id,
+                                  int value);
+int hasciicam_session_set_control_auto(hasciicam_session *session,
+                                       capture_control_id id,
+                                       int enabled);
 
 #endif

--- a/src/capture/capture.h
+++ b/src/capture/capture.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+#define CAPTURE_MAX_CONTROLS 16
+
 /* Canonical frame formats exposed by capture backends. */
 typedef enum capture_pixel_format {
     CAPTURE_PIXFMT_UNKNOWN = 0,

--- a/src/capture/capture.h
+++ b/src/capture/capture.h
@@ -58,6 +58,32 @@ typedef struct capture_info {
     capture_pixel_format pixel_format;
 } capture_info;
 
+typedef enum capture_control_id {
+    CAPTURE_CONTROL_BRIGHTNESS = 0,
+    CAPTURE_CONTROL_CONTRAST,
+    CAPTURE_CONTROL_GAMMA,
+    CAPTURE_CONTROL_GAIN,
+    CAPTURE_CONTROL_SATURATION,
+    CAPTURE_CONTROL_SHARPNESS,
+    CAPTURE_CONTROL_EXPOSURE,
+    CAPTURE_CONTROL_WHITE_BALANCE,
+    CAPTURE_CONTROL_FOCUS
+} capture_control_id;
+
+typedef struct capture_control_desc {
+    capture_control_id id;
+    const char *name;
+    const char *label;
+    int min_value;
+    int max_value;
+    int step;
+    int default_value;
+    int current_value;
+    int writable;
+    int auto_supported;
+    int auto_enabled;
+} capture_control_desc;
+
 typedef struct capture_device capture_device;
 
 typedef struct capture_ops {
@@ -77,6 +103,12 @@ typedef struct capture_ops {
     void (*close)(capture_device *dev);
     /* Stable backend identifier for diagnostics. */
     const char *(*name)(void);
+    /* Optional: enumerate supported controls. Returns count written to out[]. */
+    int (*list_controls)(capture_device *dev, capture_control_desc *out, int max_controls);
+    /* Optional: set a control value. */
+    int (*set_control)(capture_device *dev, capture_control_id id, int value);
+    /* Optional: set control auto mode (enabled=0/1). */
+    int (*set_control_auto)(capture_device *dev, capture_control_id id, int enabled);
 } capture_ops;
 
 #endif

--- a/src/capture/capture_avfoundation.mm
+++ b/src/capture/capture_avfoundation.mm
@@ -223,7 +223,10 @@ static const capture_ops ops = {
     avf_release,
     avf_stop,
     avf_close,
-    avf_name
+    avf_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_avfoundation_ops(void) {

--- a/src/capture/capture_avfoundation.mm
+++ b/src/capture/capture_avfoundation.mm
@@ -211,6 +211,27 @@ static void avf_close(capture_device *dev) {
     free(dev);
 }
 
+static int avf_list_controls(capture_device *dev, capture_control_desc *out, int max_controls) {
+    (void)dev;
+    (void)out;
+    (void)max_controls;
+    return 0;
+}
+
+static int avf_set_control(capture_device *dev, capture_control_id id, int value) {
+    (void)dev;
+    (void)id;
+    (void)value;
+    return 0;
+}
+
+static int avf_set_control_auto(capture_device *dev, capture_control_id id, int enabled) {
+    (void)dev;
+    (void)id;
+    (void)enabled;
+    return 0;
+}
+
 static const char *avf_name(void) {
     return "avfoundation";
 }
@@ -224,9 +245,9 @@ static const capture_ops ops = {
     avf_stop,
     avf_close,
     avf_name,
-    NULL,
-    NULL,
-    NULL
+    avf_list_controls,
+    avf_set_control,
+    avf_set_control_auto
 };
 
 const capture_ops *capture_avfoundation_ops(void) {

--- a/src/capture/capture_control.c
+++ b/src/capture/capture_control.c
@@ -1,0 +1,30 @@
+#include "capture_control.h"
+
+int capture_controls_list(capture_device *dev,
+                          const capture_ops *ops,
+                          capture_control_desc *out,
+                          int max_controls) {
+    if (dev == 0 || ops == 0 || out == 0 || max_controls <= 0)
+        return 0;
+    if (ops->list_controls == 0)
+        return 0;
+    return ops->list_controls(dev, out, max_controls);
+}
+
+int capture_control_set(capture_device *dev,
+                        const capture_ops *ops,
+                        capture_control_id id,
+                        int value) {
+    if (dev == 0 || ops == 0 || ops->set_control == 0)
+        return 0;
+    return ops->set_control(dev, id, value);
+}
+
+int capture_control_set_auto(capture_device *dev,
+                             const capture_ops *ops,
+                             capture_control_id id,
+                             int enabled) {
+    if (dev == 0 || ops == 0 || ops->set_control_auto == 0)
+        return 0;
+    return ops->set_control_auto(dev, id, enabled ? 1 : 0);
+}

--- a/src/capture/capture_control.h
+++ b/src/capture/capture_control.h
@@ -1,0 +1,19 @@
+#ifndef HASCIICAM_CAPTURE_CONTROL_H
+#define HASCIICAM_CAPTURE_CONTROL_H
+
+#include "capture.h"
+
+int capture_controls_list(capture_device *dev,
+                          const capture_ops *ops,
+                          capture_control_desc *out,
+                          int max_controls);
+int capture_control_set(capture_device *dev,
+                        const capture_ops *ops,
+                        capture_control_id id,
+                        int value);
+int capture_control_set_auto(capture_device *dev,
+                             const capture_ops *ops,
+                             capture_control_id id,
+                             int enabled);
+
+#endif

--- a/src/capture/capture_dshow.cpp
+++ b/src/capture/capture_dshow.cpp
@@ -459,7 +459,10 @@ static const capture_ops ops = {
     dshow_release,
     dshow_stop,
     dshow_close,
-    dshow_name
+    dshow_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_dshow_ops(void) {

--- a/src/capture/capture_dshow.cpp
+++ b/src/capture/capture_dshow.cpp
@@ -41,6 +41,8 @@ struct capture_device {
     IBaseFilter *null_renderer;
     ISampleGrabber *grabber;
     IMediaControl *media_control;
+    IAMVideoProcAmp *video_proc_amp;
+    IAMCameraControl *camera_control;
     int com_initialized;
     capture_info info;
     std::vector<unsigned char> buffer;
@@ -84,6 +86,35 @@ static int subtype_to_format(const GUID &subtype, capture_pixel_format *fmt) {
         return 1;
     }
     return 0;
+}
+
+typedef struct dshow_control_map {
+    capture_control_id id;
+    int proc_id;
+    int cam_id;
+    const char *name;
+    const char *label;
+} dshow_control_map;
+
+static const dshow_control_map g_control_map[] = {
+    {CAPTURE_CONTROL_BRIGHTNESS, VideoProcAmp_Brightness, -1, "brightness", "Brightness"},
+    {CAPTURE_CONTROL_CONTRAST, VideoProcAmp_Contrast, -1, "contrast", "Contrast"},
+    {CAPTURE_CONTROL_GAMMA, VideoProcAmp_Gamma, -1, "gamma", "Gamma"},
+    {CAPTURE_CONTROL_GAIN, VideoProcAmp_Gain, -1, "gain", "Gain"},
+    {CAPTURE_CONTROL_SATURATION, VideoProcAmp_Saturation, -1, "saturation", "Saturation"},
+    {CAPTURE_CONTROL_SHARPNESS, VideoProcAmp_Sharpness, -1, "sharpness", "Sharpness"},
+    {CAPTURE_CONTROL_EXPOSURE, -1, CameraControl_Exposure, "exposure", "Exposure"},
+    {CAPTURE_CONTROL_WHITE_BALANCE, VideoProcAmp_WhiteBalance, -1, "white_balance", "White Balance"},
+    {CAPTURE_CONTROL_FOCUS, -1, CameraControl_Focus, "focus", "Focus"}
+};
+
+static const dshow_control_map *find_control_map(capture_control_id id) {
+    size_t i;
+    for (i = 0; i < sizeof(g_control_map) / sizeof(g_control_map[0]); ++i) {
+        if (g_control_map[i].id == id)
+            return &g_control_map[i];
+    }
+    return NULL;
 }
 
 static HRESULT configure_capture_size(struct capture_device *dev, const capture_request *req) {
@@ -276,6 +307,10 @@ static HRESULT build_graph(struct capture_device *dev, IMoniker *chosen, const c
     release_media_type(&mt);
 
     hr = dev->graph->QueryInterface(IID_IMediaControl, (void **)&dev->media_control);
+    if (SUCCEEDED(hr)) {
+        dev->source_filter->QueryInterface(IID_IAMVideoProcAmp, (void **)&dev->video_proc_amp);
+        dev->source_filter->QueryInterface(IID_IAMCameraControl, (void **)&dev->camera_control);
+    }
     return hr;
 }
 
@@ -392,6 +427,8 @@ static void dshow_close(capture_device *dev) {
     if (dev == NULL)
         return;
     dshow_stop(dev);
+    if (dev->video_proc_amp) dev->video_proc_amp->Release();
+    if (dev->camera_control) dev->camera_control->Release();
     if (dev->media_control) dev->media_control->Release();
     if (dev->grabber) dev->grabber->Release();
     release_filter(dev->null_renderer);
@@ -401,6 +438,79 @@ static void dshow_close(capture_device *dev) {
     if (dev->graph) dev->graph->Release();
     if (dev->com_initialized) CoUninitialize();
     delete dev;
+}
+
+static int dshow_list_controls(capture_device *dev, capture_control_desc *out, int max_controls) {
+    int count = 0;
+    size_t i;
+    if (dev == NULL || out == NULL || max_controls <= 0)
+        return 0;
+    for (i = 0; i < sizeof(g_control_map) / sizeof(g_control_map[0]) && count < max_controls; ++i) {
+        long minv = 0;
+        long maxv = 0;
+        long step = 0;
+        long defv = 0;
+        long caps = 0;
+        long cur = 0;
+        long flags = 0;
+        HRESULT hr = E_FAIL;
+        if (g_control_map[i].proc_id >= 0 && dev->video_proc_amp != NULL) {
+            hr = dev->video_proc_amp->GetRange(g_control_map[i].proc_id, &minv, &maxv, &step, &defv, &caps);
+            if (SUCCEEDED(hr))
+                hr = dev->video_proc_amp->Get(g_control_map[i].proc_id, &cur, &flags);
+        } else if (g_control_map[i].cam_id >= 0 && dev->camera_control != NULL) {
+            hr = dev->camera_control->GetRange(g_control_map[i].cam_id, &minv, &maxv, &step, &defv, &caps);
+            if (SUCCEEDED(hr))
+                hr = dev->camera_control->Get(g_control_map[i].cam_id, &cur, &flags);
+        }
+        if (FAILED(hr))
+            continue;
+        out[count].id = g_control_map[i].id;
+        out[count].name = g_control_map[i].name;
+        out[count].label = g_control_map[i].label;
+        out[count].min_value = (int)minv;
+        out[count].max_value = (int)maxv;
+        out[count].step = (int)(step > 0 ? step : 1);
+        out[count].default_value = (int)defv;
+        out[count].current_value = (int)cur;
+        out[count].writable = 1;
+        out[count].auto_supported = (caps & VideoProcAmp_Flags_Auto) || (caps & CameraControl_Flags_Auto) ? 1 : 0;
+        out[count].auto_enabled = ((flags & VideoProcAmp_Flags_Auto) || (flags & CameraControl_Flags_Auto)) ? 1 : 0;
+        count++;
+    }
+    return count;
+}
+
+static int dshow_set_control(capture_device *dev, capture_control_id id, int value) {
+    const dshow_control_map *map = find_control_map(id);
+    if (dev == NULL || map == NULL)
+        return 0;
+    if (map->proc_id >= 0 && dev->video_proc_amp != NULL)
+        return SUCCEEDED(dev->video_proc_amp->Set(map->proc_id, value, VideoProcAmp_Flags_Manual)) ? 1 : 0;
+    if (map->cam_id >= 0 && dev->camera_control != NULL)
+        return SUCCEEDED(dev->camera_control->Set(map->cam_id, value, CameraControl_Flags_Manual)) ? 1 : 0;
+    return 0;
+}
+
+static int dshow_set_control_auto(capture_device *dev, capture_control_id id, int enabled) {
+    const dshow_control_map *map = find_control_map(id);
+    long current = 0;
+    long flags = 0;
+    if (dev == NULL || map == NULL)
+        return 0;
+    if (map->proc_id >= 0 && dev->video_proc_amp != NULL) {
+        if (FAILED(dev->video_proc_amp->Get(map->proc_id, &current, &flags)))
+            return 0;
+        return SUCCEEDED(dev->video_proc_amp->Set(map->proc_id, current,
+                                                  enabled ? VideoProcAmp_Flags_Auto : VideoProcAmp_Flags_Manual)) ? 1 : 0;
+    }
+    if (map->cam_id >= 0 && dev->camera_control != NULL) {
+        if (FAILED(dev->camera_control->Get(map->cam_id, &current, &flags)))
+            return 0;
+        return SUCCEEDED(dev->camera_control->Set(map->cam_id, current,
+                                                  enabled ? CameraControl_Flags_Auto : CameraControl_Flags_Manual)) ? 1 : 0;
+    }
+    return 0;
 }
 
 #else
@@ -460,9 +570,9 @@ static const capture_ops ops = {
     dshow_stop,
     dshow_close,
     dshow_name,
-    NULL,
-    NULL,
-    NULL
+    dshow_list_controls,
+    dshow_set_control,
+    dshow_set_control_auto
 };
 
 const capture_ops *capture_dshow_ops(void) {

--- a/src/capture/capture_external.c
+++ b/src/capture/capture_external.c
@@ -98,7 +98,10 @@ static const capture_ops ops = {
     external_release,
     external_stop,
     external_close,
-    external_name
+    external_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_external_ops(void) {

--- a/src/capture/capture_mf.c
+++ b/src/capture/capture_mf.c
@@ -496,7 +496,10 @@ static const capture_ops ops = {
     mf_release,
     mf_stop,
     mf_close,
-    mf_name
+    mf_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_mf_ops(void) {

--- a/src/capture/capture_mf.c
+++ b/src/capture/capture_mf.c
@@ -439,6 +439,27 @@ static void mf_close(capture_device *dev) {
     free(dev);
 }
 
+static int mf_list_controls(capture_device *dev, capture_control_desc *out, int max_controls) {
+    (void)dev;
+    (void)out;
+    (void)max_controls;
+    return 0;
+}
+
+static int mf_set_control(capture_device *dev, capture_control_id id, int value) {
+    (void)dev;
+    (void)id;
+    (void)value;
+    return 0;
+}
+
+static int mf_set_control_auto(capture_device *dev, capture_control_id id, int enabled) {
+    (void)dev;
+    (void)id;
+    (void)enabled;
+    return 0;
+}
+
 #else
 
 struct capture_device {
@@ -497,9 +518,9 @@ static const capture_ops ops = {
     mf_stop,
     mf_close,
     mf_name,
-    NULL,
-    NULL,
-    NULL
+    mf_list_controls,
+    mf_set_control,
+    mf_set_control_auto
 };
 
 const capture_ops *capture_mf_ops(void) {

--- a/src/capture/capture_synthetic.c
+++ b/src/capture/capture_synthetic.c
@@ -111,7 +111,10 @@ static const capture_ops ops = {
     synthetic_release,
     synthetic_stop,
     synthetic_close,
-    synthetic_name
+    synthetic_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_synthetic_ops(void) {

--- a/src/capture/capture_v4l2.c
+++ b/src/capture/capture_v4l2.c
@@ -32,6 +32,35 @@ struct capture_device {
     struct v4l2_buffer_map *buffers;
 };
 
+typedef struct v4l2_control_map {
+    capture_control_id id;
+    unsigned int cid;
+    unsigned int cid_auto;
+    const char *name;
+    const char *label;
+} v4l2_control_map;
+
+static const v4l2_control_map g_v4l2_controls[] = {
+    {CAPTURE_CONTROL_BRIGHTNESS, V4L2_CID_BRIGHTNESS, 0, "brightness", "Brightness"},
+    {CAPTURE_CONTROL_CONTRAST, V4L2_CID_CONTRAST, 0, "contrast", "Contrast"},
+    {CAPTURE_CONTROL_GAMMA, V4L2_CID_GAMMA, 0, "gamma", "Gamma"},
+    {CAPTURE_CONTROL_GAIN, V4L2_CID_GAIN, 0, "gain", "Gain"},
+    {CAPTURE_CONTROL_SATURATION, V4L2_CID_SATURATION, 0, "saturation", "Saturation"},
+    {CAPTURE_CONTROL_SHARPNESS, V4L2_CID_SHARPNESS, 0, "sharpness", "Sharpness"},
+    {CAPTURE_CONTROL_EXPOSURE, V4L2_CID_EXPOSURE_ABSOLUTE, V4L2_CID_EXPOSURE_AUTO, "exposure", "Exposure"},
+    {CAPTURE_CONTROL_WHITE_BALANCE, V4L2_CID_WHITE_BALANCE_TEMPERATURE, V4L2_CID_AUTO_WHITE_BALANCE, "white_balance", "White Balance"},
+    {CAPTURE_CONTROL_FOCUS, V4L2_CID_FOCUS_ABSOLUTE, V4L2_CID_FOCUS_AUTO, "focus", "Focus"}
+};
+
+static const v4l2_control_map *find_v4l2_control(capture_control_id id) {
+    size_t i;
+    for (i = 0; i < sizeof(g_v4l2_controls) / sizeof(g_v4l2_controls[0]); ++i) {
+        if (g_v4l2_controls[i].id == id)
+            return &g_v4l2_controls[i];
+    }
+    return NULL;
+}
+
 static void v4l2_stop(capture_device *dev);
 
 static int clamp_to_step(int value, int min_v, int max_v, int step_v) {
@@ -390,6 +419,77 @@ static void v4l2_close(capture_device *dev) {
     free(dev);
 }
 
+static int v4l2_list_controls(capture_device *dev, capture_control_desc *out, int max_controls) {
+    int count = 0;
+    size_t i;
+    if (dev == NULL || out == NULL || max_controls <= 0)
+        return 0;
+    for (i = 0; i < sizeof(g_v4l2_controls) / sizeof(g_v4l2_controls[0]) && count < max_controls; ++i) {
+        struct v4l2_queryctrl q;
+        struct v4l2_control c;
+        struct v4l2_control a;
+        memset(&q, 0, sizeof(q));
+        q.id = g_v4l2_controls[i].cid;
+        if (ioctl(dev->fd, VIDIOC_QUERYCTRL, &q) == -1)
+            continue;
+        if (q.flags & (V4L2_CTRL_FLAG_DISABLED | V4L2_CTRL_FLAG_INACTIVE))
+            continue;
+        memset(&c, 0, sizeof(c));
+        c.id = g_v4l2_controls[i].cid;
+        if (ioctl(dev->fd, VIDIOC_G_CTRL, &c) == -1)
+            continue;
+        out[count].id = g_v4l2_controls[i].id;
+        out[count].name = g_v4l2_controls[i].name;
+        out[count].label = g_v4l2_controls[i].label;
+        out[count].min_value = q.minimum;
+        out[count].max_value = q.maximum;
+        out[count].step = q.step > 0 ? q.step : 1;
+        out[count].default_value = q.default_value;
+        out[count].current_value = c.value;
+        out[count].writable = 1;
+        out[count].auto_supported = 0;
+        out[count].auto_enabled = 0;
+        if (g_v4l2_controls[i].cid_auto != 0) {
+            struct v4l2_queryctrl qa;
+            memset(&qa, 0, sizeof(qa));
+            qa.id = g_v4l2_controls[i].cid_auto;
+            if (ioctl(dev->fd, VIDIOC_QUERYCTRL, &qa) != -1 &&
+                !(qa.flags & (V4L2_CTRL_FLAG_DISABLED | V4L2_CTRL_FLAG_INACTIVE))) {
+                memset(&a, 0, sizeof(a));
+                a.id = g_v4l2_controls[i].cid_auto;
+                if (ioctl(dev->fd, VIDIOC_G_CTRL, &a) != -1) {
+                    out[count].auto_supported = 1;
+                    out[count].auto_enabled = a.value ? 1 : 0;
+                }
+            }
+        }
+        count++;
+    }
+    return count;
+}
+
+static int v4l2_set_control(capture_device *dev, capture_control_id id, int value) {
+    const v4l2_control_map *map = find_v4l2_control(id);
+    struct v4l2_control c;
+    if (dev == NULL || map == NULL)
+        return 0;
+    memset(&c, 0, sizeof(c));
+    c.id = map->cid;
+    c.value = value;
+    return ioctl(dev->fd, VIDIOC_S_CTRL, &c) == -1 ? 0 : 1;
+}
+
+static int v4l2_set_control_auto(capture_device *dev, capture_control_id id, int enabled) {
+    const v4l2_control_map *map = find_v4l2_control(id);
+    struct v4l2_control c;
+    if (dev == NULL || map == NULL || map->cid_auto == 0)
+        return 0;
+    memset(&c, 0, sizeof(c));
+    c.id = map->cid_auto;
+    c.value = enabled ? 1 : 0;
+    return ioctl(dev->fd, VIDIOC_S_CTRL, &c) == -1 ? 0 : 1;
+}
+
 static const char *v4l2_name(void) {
     return "v4l2";
 }
@@ -403,9 +503,9 @@ static const capture_ops ops = {
     v4l2_stop,
     v4l2_close,
     v4l2_name,
-    NULL,
-    NULL,
-    NULL
+    v4l2_list_controls,
+    v4l2_set_control,
+    v4l2_set_control_auto
 };
 
 const capture_ops *capture_v4l2_ops(void) {

--- a/src/capture/capture_v4l2.c
+++ b/src/capture/capture_v4l2.c
@@ -402,7 +402,10 @@ static const capture_ops ops = {
     v4l2_release,
     v4l2_stop,
     v4l2_close,
-    v4l2_name
+    v4l2_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_v4l2_ops(void) {
@@ -464,7 +467,10 @@ static const capture_ops ops = {
     unsupported_release,
     unsupported_stop,
     unsupported_close,
-    unsupported_name
+    unsupported_name,
+    NULL,
+    NULL,
+    NULL
 };
 
 const capture_ops *capture_v4l2_ops(void) {

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -193,6 +193,42 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     ImGui::Text("Size: %dx%d", state->capture_width, state->capture_height);
     ImGui::Text("Stride: %d bytes", state->capture_stride_bytes);
     ImGui::Text("Pixel format: %d", (int)state->capture_pixel_format);
+    ImGui::Separator();
+    ImGui::Text("Camera Controls");
+    if (state->capture_control_count <= 0) {
+        ImGui::TextDisabled("No camera controls");
+    } else {
+        int i;
+        for (i = 0; i < state->capture_control_count; ++i) {
+            capture_control_desc *c = &state->capture_controls[i];
+            int value = c->current_value;
+            if (c->auto_supported) {
+                bool is_auto = c->auto_enabled ? true : false;
+                char auto_label[80];
+                snprintf(auto_label, sizeof(auto_label), "%s auto", c->label ? c->label : c->name);
+                if (ImGui::Checkbox(auto_label, &is_auto)) {
+                    c->auto_enabled = is_auto ? 1 : 0;
+                    state->capture_control_change_requested = 1;
+                    state->capture_control_change_is_auto = 1;
+                    state->capture_control_change_id = c->id;
+                    state->capture_control_change_value = c->auto_enabled;
+                }
+            }
+            if (c->writable && !c->auto_enabled) {
+                char slider_label[80];
+                snprintf(slider_label, sizeof(slider_label), "%s", c->label ? c->label : c->name);
+                if (ImGui::SliderInt(slider_label, &value, c->min_value, c->max_value)) {
+                    c->current_value = value;
+                    state->capture_control_change_requested = 1;
+                    state->capture_control_change_is_auto = 0;
+                    state->capture_control_change_id = c->id;
+                    state->capture_control_change_value = value;
+                }
+            } else {
+                ImGui::Text("%s: %d", c->label ? c->label : c->name, c->current_value);
+            }
+        }
+    }
 
     ImGui::Separator();
     ImGui::Text("Pre-AA Preview");

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -11,6 +11,11 @@
 #include "../render/render_font.h"
 
 static int g_initialized = 0;
+static SDL_Renderer *g_renderer = NULL;
+static SDL_Texture *g_preview_texture = NULL;
+static int g_preview_width = 0;
+static int g_preview_height = 0;
+static unsigned int g_preview_generation = 0;
 
 static void rgb_to_float3(unsigned int rgb, float out_rgb[3]) {
     out_rgb[0] = ((rgb >> 16) & 0xFF) / 255.0f;
@@ -37,6 +42,7 @@ int hasciicam_gui_overlay_init(SDL_Window *window, SDL_Renderer *renderer) {
         return 0;
     if (!ImGui_ImplSDLRenderer2_Init(renderer))
         return 0;
+    g_renderer = renderer;
     g_initialized = 1;
     return 1;
 }
@@ -44,10 +50,61 @@ int hasciicam_gui_overlay_init(SDL_Window *window, SDL_Renderer *renderer) {
 void hasciicam_gui_overlay_shutdown(void) {
     if (!g_initialized)
         return;
+    if (g_preview_texture != NULL) {
+        SDL_DestroyTexture(g_preview_texture);
+        g_preview_texture = NULL;
+    }
+    g_renderer = NULL;
+    g_preview_width = 0;
+    g_preview_height = 0;
+    g_preview_generation = 0;
     ImGui_ImplSDLRenderer2_Shutdown();
     ImGui_ImplSDL2_Shutdown();
     ImGui::DestroyContext();
     g_initialized = 0;
+}
+
+static void update_preview_texture(const hasciicam_gui_state *state) {
+    int x;
+    int y;
+    int pitch;
+    void *pixels = NULL;
+    if (!g_initialized || state == NULL || g_renderer == NULL)
+        return;
+    if (state->preview_gray == NULL || state->preview_width <= 0 || state->preview_height <= 0)
+        return;
+    if (g_preview_generation == state->preview_generation)
+        return;
+    if (g_preview_texture != NULL &&
+        (g_preview_width != state->preview_width || g_preview_height != state->preview_height)) {
+        SDL_DestroyTexture(g_preview_texture);
+        g_preview_texture = NULL;
+        g_preview_width = 0;
+        g_preview_height = 0;
+    }
+    if (g_preview_texture == NULL) {
+        g_preview_texture = SDL_CreateTexture(g_renderer,
+                                              SDL_PIXELFORMAT_ARGB8888,
+                                              SDL_TEXTUREACCESS_STREAMING,
+                                              state->preview_width,
+                                              state->preview_height);
+        if (g_preview_texture == NULL)
+            return;
+        g_preview_width = state->preview_width;
+        g_preview_height = state->preview_height;
+    }
+    if (SDL_LockTexture(g_preview_texture, NULL, &pixels, &pitch) != 0)
+        return;
+    for (y = 0; y < state->preview_height; ++y) {
+        Uint32 *row = (Uint32 *)((unsigned char *)pixels + (size_t)y * (size_t)pitch);
+        const unsigned char *src = state->preview_gray + (size_t)y * (size_t)state->preview_stride;
+        for (x = 0; x < state->preview_width; ++x) {
+            unsigned int g = src[x];
+            row[x] = 0xFF000000u | (g << 16) | (g << 8) | g;
+        }
+    }
+    SDL_UnlockTexture(g_preview_texture);
+    g_preview_generation = state->preview_generation;
 }
 
 void hasciicam_gui_overlay_new_frame(void) {
@@ -73,6 +130,7 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
 
     if (!g_initialized || state == NULL)
         return;
+    update_preview_texture(state);
 
     ImGui::SetNextWindowSize(ImVec2(360.0f, 0.0f), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowBgAlpha(0.92f);
@@ -135,6 +193,16 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     ImGui::Text("Size: %dx%d", state->capture_width, state->capture_height);
     ImGui::Text("Stride: %d bytes", state->capture_stride_bytes);
     ImGui::Text("Pixel format: %d", (int)state->capture_pixel_format);
+
+    ImGui::Separator();
+    ImGui::Text("Pre-AA Preview");
+    if (g_preview_texture != NULL && state->preview_width > 0 && state->preview_height > 0) {
+        float preview_w = 180.0f;
+        float preview_h = (preview_w * (float)state->preview_height) / (float)state->preview_width;
+        ImGui::Image((ImTextureID)g_preview_texture, ImVec2(preview_w, preview_h));
+    } else {
+        ImGui::TextDisabled("No preview yet");
+    }
 
     ImGui::Separator();
     ImGui::Text("Colors");

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -184,6 +184,7 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
 
     ImGui::Separator();
     ImGui::Text("Capture");
+    ImGui::BeginGroup();
     mirror_x = state->mirror_x != 0;
     mirror_y = state->mirror_y != 0;
     if (ImGui::Checkbox("Mirror X", &mirror_x))
@@ -193,6 +194,29 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     ImGui::Text("Size: %dx%d", state->capture_width, state->capture_height);
     ImGui::Text("Stride: %d bytes", state->capture_stride_bytes);
     ImGui::Text("Pixel format: %d", (int)state->capture_pixel_format);
+    ImGui::EndGroup();
+    if (g_preview_texture != NULL && state->preview_width > 0 && state->preview_height > 0) {
+        float aspect_w = (float)state->preview_width;
+        float aspect_h = (float)state->preview_height;
+        float preview_w;
+        float preview_h;
+        if (state->capture_width > 0 && state->capture_height > 0) {
+            aspect_w = (float)state->capture_width;
+            aspect_h = (float)state->capture_height;
+        }
+        if (aspect_w <= 0.0f || aspect_h <= 0.0f) {
+            aspect_w = 4.0f;
+            aspect_h = 3.0f;
+        }
+        preview_w = 150.0f;
+        preview_h = preview_w * (aspect_h / aspect_w);
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - preview_w);
+        ImGui::Image((ImTextureID)g_preview_texture, ImVec2(preview_w, preview_h));
+    } else {
+        ImGui::SameLine();
+        ImGui::TextDisabled("No preview yet");
+    }
     ImGui::Separator();
     ImGui::Text("Camera Controls");
     if (state->capture_control_count <= 0) {
@@ -228,16 +252,6 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
                 ImGui::Text("%s: %d", c->label ? c->label : c->name, c->current_value);
             }
         }
-    }
-
-    ImGui::Separator();
-    ImGui::Text("Pre-AA Preview");
-    if (g_preview_texture != NULL && state->preview_width > 0 && state->preview_height > 0) {
-        float preview_w = 180.0f;
-        float preview_h = (preview_w * (float)state->preview_height) / (float)state->preview_width;
-        ImGui::Image((ImTextureID)g_preview_texture, ImVec2(preview_w, preview_h));
-    } else {
-        ImGui::TextDisabled("No preview yet");
     }
 
     ImGui::Separator();

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -217,11 +217,9 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
         ImGui::SameLine();
         ImGui::TextDisabled("No preview yet");
     }
-    ImGui::Separator();
-    ImGui::Text("Camera Controls");
-    if (state->capture_control_count <= 0) {
-        ImGui::TextDisabled("No camera controls");
-    } else {
+    if (state->capture_control_count > 0) {
+        ImGui::Separator();
+        ImGui::Text("Camera Controls");
         int i;
         for (i = 0; i < state->capture_control_count; ++i) {
             capture_control_desc *c = &state->capture_controls[i];

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -96,6 +96,22 @@ void hasciicam_gui_state_set_capture_info(hasciicam_gui_state *state, const capt
     state->capture_pixel_format = info->pixel_format;
 }
 
+void hasciicam_gui_state_set_capture_controls(hasciicam_gui_state *state,
+                                              const capture_control_desc *controls,
+                                              int control_count) {
+    int i;
+    if (state == NULL)
+        return;
+    if (control_count < 0)
+        control_count = 0;
+    if (control_count > CAPTURE_MAX_CONTROLS)
+        control_count = CAPTURE_MAX_CONTROLS;
+    state->capture_control_count = control_count;
+    for (i = 0; i < control_count; ++i) {
+        state->capture_controls[i] = controls[i];
+    }
+}
+
 int hasciicam_gui_state_update_preview(hasciicam_gui_state *state,
                                        const unsigned char *gray_frame,
                                        int width,

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -1,6 +1,7 @@
 #include "gui_state.h"
 
 #include <ctype.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -93,4 +94,42 @@ void hasciicam_gui_state_set_capture_info(hasciicam_gui_state *state, const capt
     state->capture_height = info->height;
     state->capture_stride_bytes = info->stride_bytes;
     state->capture_pixel_format = info->pixel_format;
+}
+
+int hasciicam_gui_state_update_preview(hasciicam_gui_state *state,
+                                       const unsigned char *gray_frame,
+                                       int width,
+                                       int height) {
+    int size;
+    if (state == NULL || gray_frame == NULL || width <= 0 || height <= 0)
+        return 0;
+    size = width * height;
+    if (size <= 0)
+        return 0;
+    if (state->preview_capacity < size) {
+        unsigned char *new_buf = (unsigned char *)malloc((size_t)size);
+        if (new_buf == NULL)
+            return 0;
+        free(state->preview_gray);
+        state->preview_gray = new_buf;
+        state->preview_capacity = size;
+    }
+    memcpy(state->preview_gray, gray_frame, (size_t)size);
+    state->preview_width = width;
+    state->preview_height = height;
+    state->preview_stride = width;
+    state->preview_generation++;
+    return 1;
+}
+
+void hasciicam_gui_state_reset_preview(hasciicam_gui_state *state) {
+    if (state == NULL)
+        return;
+    free(state->preview_gray);
+    state->preview_gray = NULL;
+    state->preview_capacity = 0;
+    state->preview_width = 0;
+    state->preview_height = 0;
+    state->preview_stride = 0;
+    state->preview_generation = 0;
 }

--- a/src/gui/gui_state.h
+++ b/src/gui/gui_state.h
@@ -27,6 +27,12 @@ typedef struct hasciicam_gui_state {
     int capture_height;
     int capture_stride_bytes;
     capture_pixel_format capture_pixel_format;
+    capture_control_desc capture_controls[CAPTURE_MAX_CONTROLS];
+    int capture_control_count;
+    int capture_control_change_requested;
+    int capture_control_change_is_auto;
+    capture_control_id capture_control_change_id;
+    int capture_control_change_value;
     unsigned char *preview_gray;
     int preview_capacity;
     int preview_width;
@@ -58,6 +64,9 @@ void hasciicam_gui_state_copy_to_config(const hasciicam_gui_state *state, hascii
  * Set capture info fields shown in the GUI panel.
  */
 void hasciicam_gui_state_set_capture_info(hasciicam_gui_state *state, const capture_info *info);
+void hasciicam_gui_state_set_capture_controls(hasciicam_gui_state *state,
+                                              const capture_control_desc *controls,
+                                              int control_count);
 int hasciicam_gui_state_update_preview(hasciicam_gui_state *state,
                                        const unsigned char *gray_frame,
                                        int width,

--- a/src/gui/gui_state.h
+++ b/src/gui/gui_state.h
@@ -27,6 +27,12 @@ typedef struct hasciicam_gui_state {
     int capture_height;
     int capture_stride_bytes;
     capture_pixel_format capture_pixel_format;
+    unsigned char *preview_gray;
+    int preview_capacity;
+    int preview_width;
+    int preview_height;
+    int preview_stride;
+    unsigned int preview_generation;
 
     char save_path[260];
     char load_path[260];
@@ -52,6 +58,11 @@ void hasciicam_gui_state_copy_to_config(const hasciicam_gui_state *state, hascii
  * Set capture info fields shown in the GUI panel.
  */
 void hasciicam_gui_state_set_capture_info(hasciicam_gui_state *state, const capture_info *info);
+int hasciicam_gui_state_update_preview(hasciicam_gui_state *state,
+                                       const unsigned char *gray_frame,
+                                       int width,
+                                       int height);
+void hasciicam_gui_state_reset_preview(hasciicam_gui_state *state);
 
 /**
  * Parse a 6-digit RGB hex string into 0xRRGGBB.

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -129,6 +129,8 @@ main (int argc, char **argv) {
   hasciicam_render_session render_session;
   hasciicam_gui_state gui_state;
   hasciicam_output output;
+  capture_control_desc control_descs[CAPTURE_MAX_CONTROLS];
+  int control_count = 0;
   struct geometry aa_geo;
   struct geometry vid_geo;
   int mode;
@@ -363,6 +365,8 @@ main (int argc, char **argv) {
   render_session.render_params->inversion = appcfg.invert ? 1 : 0;
   hasciicam_gui_state_init(&gui_state, &appcfg);
   hasciicam_gui_state_set_capture_info(&gui_state, cap_info);
+  control_count = hasciicam_session_list_controls(&session, control_descs, CAPTURE_MAX_CONTROLS);
+  hasciicam_gui_state_set_capture_controls(&gui_state, control_descs, control_count);
   hasciicam_sdl_set_runtime_colors(render_session.context,
                                    gui_state.foreground_rgb,
                                    gui_state.background_rgb);
@@ -449,6 +453,8 @@ main (int argc, char **argv) {
         strncpy(gui_state.save_path, saved_path, sizeof(gui_state.save_path) - 1);
         gui_state.save_path[sizeof(gui_state.save_path) - 1] = '\0';
         hasciicam_gui_state_set_capture_info(&gui_state, cap_info);
+        control_count = hasciicam_session_list_controls(&session, control_descs, CAPTURE_MAX_CONTROLS);
+        hasciicam_gui_state_set_capture_controls(&gui_state, control_descs, control_count);
         if (strcmp(previous_font, gui_state.font) != 0)
           gui_state.font_change_requested = 1;
         strncpy(gui_state.active_font, previous_font, sizeof(gui_state.active_font) - 1);
@@ -464,6 +470,28 @@ main (int argc, char **argv) {
     }
 
     hasciicam_live_controls_apply(&render_session, &session, &appcfg, &gui_state);
+    if (gui_state.capture_control_change_requested) {
+      gui_state.capture_control_change_requested = 0;
+      if (gui_state.capture_control_change_is_auto) {
+        if (!hasciicam_session_set_control_auto(&session,
+                                                gui_state.capture_control_change_id,
+                                                gui_state.capture_control_change_value)) {
+          snprintf(gui_state.status_message, sizeof(gui_state.status_message),
+                   "camera auto change failed");
+          gui_state.status_is_error = 1;
+        }
+      } else {
+        if (!hasciicam_session_set_control(&session,
+                                           gui_state.capture_control_change_id,
+                                           gui_state.capture_control_change_value)) {
+          snprintf(gui_state.status_message, sizeof(gui_state.status_message),
+                   "camera control change failed");
+          gui_state.status_is_error = 1;
+        }
+      }
+      control_count = hasciicam_session_list_controls(&session, control_descs, CAPTURE_MAX_CONTROLS);
+      hasciicam_gui_state_set_capture_controls(&gui_state, control_descs, control_count);
+    }
     if (gui_state.font_change_requested) {
       gui_state.font_change_requested = 0;
       if (hasciicam_sdl_set_runtime_font(render_session.context, gui_state.font)) {

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -442,6 +442,7 @@ main (int argc, char **argv) {
         char previous_font[64];
         strncpy(previous_font, gui_state.active_font, sizeof(previous_font) - 1);
         previous_font[sizeof(previous_font) - 1] = '\0';
+        hasciicam_gui_state_reset_preview(&gui_state);
         hasciicam_gui_state_init(&gui_state, &appcfg);
         strncpy(gui_state.load_path, loaded_path, sizeof(gui_state.load_path) - 1);
         gui_state.load_path[sizeof(gui_state.load_path) - 1] = '\0';
@@ -492,6 +493,7 @@ main (int argc, char **argv) {
       int copy_size;
 
       framenum = 0;
+      hasciicam_gui_state_update_preview(&gui_state, gray_frame, ascii_width, ascii_height);
       dest_size = aa_imgwidth(render_session.context) * aa_imgheight(render_session.context);
       copy_size = (gray_size < dest_size) ? gray_size : dest_size;
       if (copy_size > 0) {
@@ -522,6 +524,7 @@ main (int argc, char **argv) {
   /* CLEAN EXIT */
 
   hasciicam_session_stop(&session);
+  hasciicam_gui_state_reset_preview(&gui_state);
   hasciicam_output_close(&output);
   hasciicam_render_session_close(&render_session);
   fprintf (stderr, "cya!\n");

--- a/tests/test_capture_control.c
+++ b/tests/test_capture_control.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "../src/capture/capture_control.h"
+
+static int g_set_called = 0;
+static int g_set_auto_called = 0;
+
+static int fake_list(capture_device *dev, capture_control_desc *out, int max_controls) {
+    (void)dev;
+    if (out == NULL || max_controls < 1)
+        return 0;
+    memset(out, 0, sizeof(*out));
+    out[0].id = CAPTURE_CONTROL_BRIGHTNESS;
+    out[0].name = "brightness";
+    out[0].min_value = 0;
+    out[0].max_value = 255;
+    out[0].current_value = 128;
+    out[0].writable = 1;
+    return 1;
+}
+
+static int fake_set(capture_device *dev, capture_control_id id, int value) {
+    (void)dev;
+    if (id != CAPTURE_CONTROL_BRIGHTNESS || value != 140)
+        return 0;
+    g_set_called = 1;
+    return 1;
+}
+
+static int fake_set_auto(capture_device *dev, capture_control_id id, int enabled) {
+    (void)dev;
+    if (id != CAPTURE_CONTROL_BRIGHTNESS || enabled != 1)
+        return 0;
+    g_set_auto_called = 1;
+    return 1;
+}
+
+static int expect_true(int cond, const char *msg) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", msg);
+        return 0;
+    }
+    return 1;
+}
+
+int main(void) {
+    capture_control_desc desc[4];
+    capture_ops ops;
+
+    memset(&ops, 0, sizeof(ops));
+    memset(desc, 0, sizeof(desc));
+
+    if (!expect_true(capture_controls_list((capture_device *)1, &ops, desc, 4) == 0,
+                     "list should return zero without backend hook")) return 1;
+    if (!expect_true(capture_control_set((capture_device *)1, &ops, CAPTURE_CONTROL_BRIGHTNESS, 1) == 0,
+                     "set should fail without backend hook")) return 1;
+    if (!expect_true(capture_control_set_auto((capture_device *)1, &ops, CAPTURE_CONTROL_BRIGHTNESS, 1) == 0,
+                     "set_auto should fail without backend hook")) return 1;
+
+    ops.list_controls = fake_list;
+    ops.set_control = fake_set;
+    ops.set_control_auto = fake_set_auto;
+
+    if (!expect_true(capture_controls_list((capture_device *)1, &ops, desc, 4) == 1,
+                     "list should report one control")) return 1;
+    if (!expect_true(strcmp(desc[0].name, "brightness") == 0,
+                     "control name should match")) return 1;
+    if (!expect_true(capture_control_set((capture_device *)1, &ops, CAPTURE_CONTROL_BRIGHTNESS, 140) == 1,
+                     "set should succeed")) return 1;
+    if (!expect_true(capture_control_set_auto((capture_device *)1, &ops, CAPTURE_CONTROL_BRIGHTNESS, 1) == 1,
+                     "set_auto should succeed")) return 1;
+    if (!expect_true(g_set_called == 1 && g_set_auto_called == 1,
+                     "hooks should be called")) return 1;
+
+    printf("capture_control tests passed\n");
+    return 0;
+}

--- a/tests/test_gui_state.c
+++ b/tests/test_gui_state.c
@@ -14,6 +14,7 @@ static int expect_true(int condition, const char *message) {
 int main(void) {
     hasciicam_config cfg;
     hasciicam_gui_state state;
+    capture_control_desc controls[2];
     unsigned char sample[6] = {0, 64, 128, 192, 224, 255};
     unsigned int rgb = 0;
 
@@ -65,6 +66,19 @@ int main(void) {
     if (!expect_true(strcmp(cfg.background, "0000FF") == 0, "background copy failed")) return 1;
     if (!expect_true(strcmp(cfg.foreground, "FF0000") == 0, "foreground copy failed")) return 1;
     if (!expect_true(strcmp(cfg.font, "vga8") == 0, "font copy failed")) return 1;
+
+    memset(controls, 0, sizeof(controls));
+    controls[0].id = CAPTURE_CONTROL_BRIGHTNESS;
+    controls[0].name = "brightness";
+    controls[0].label = "Brightness";
+    controls[0].min_value = 0;
+    controls[0].max_value = 255;
+    controls[0].current_value = 100;
+    controls[0].writable = 1;
+    hasciicam_gui_state_set_capture_controls(&state, controls, 1);
+    if (!expect_true(state.capture_control_count == 1, "capture control count failed")) return 1;
+    if (!expect_true(state.capture_controls[0].id == CAPTURE_CONTROL_BRIGHTNESS, "capture control id failed")) return 1;
+    if (!expect_true(state.capture_controls[0].current_value == 100, "capture control copy failed")) return 1;
 
     if (!expect_true(hasciicam_gui_state_update_preview(&state, sample, 3, 2) == 1,
                      "preview update failed")) return 1;

--- a/tests/test_gui_state.c
+++ b/tests/test_gui_state.c
@@ -14,6 +14,7 @@ static int expect_true(int condition, const char *message) {
 int main(void) {
     hasciicam_config cfg;
     hasciicam_gui_state state;
+    unsigned char sample[6] = {0, 64, 128, 192, 224, 255};
     unsigned int rgb = 0;
 
     memset(&cfg, 0, sizeof(cfg));
@@ -64,6 +65,16 @@ int main(void) {
     if (!expect_true(strcmp(cfg.background, "0000FF") == 0, "background copy failed")) return 1;
     if (!expect_true(strcmp(cfg.foreground, "FF0000") == 0, "foreground copy failed")) return 1;
     if (!expect_true(strcmp(cfg.font, "vga8") == 0, "font copy failed")) return 1;
+
+    if (!expect_true(hasciicam_gui_state_update_preview(&state, sample, 3, 2) == 1,
+                     "preview update failed")) return 1;
+    if (!expect_true(state.preview_width == 3 && state.preview_height == 2,
+                     "preview size failed")) return 1;
+    if (!expect_true(state.preview_gray != NULL && state.preview_gray[1] == 64 && state.preview_gray[5] == 255,
+                     "preview copy failed")) return 1;
+    hasciicam_gui_state_reset_preview(&state);
+    if (!expect_true(state.preview_gray == NULL && state.preview_capacity == 0,
+                     "preview reset failed")) return 1;
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add optional capture-control port APIs and backend coverage
- wire DirectShow (Windows) camera controls into the live ImGui overlay
- add opaque pre-AA grayscale preview in the SDL GUI
- move preview into Capture section with aspect preservation and hide empty Camera Controls section
- document capture controls and pre-AA preview behavior

## Validation
- built with `windows-vcpkg-ninja`
- ran `ctest --preset windows-vcpkg-ninja` (`22/22` passing)

## Notes
- section is omitted when no camera controls are exposed by the active backend
- preview is rendered opaque and keeps source capture aspect ratio