### PR TITLE
fix: make SDL CI builds use configured drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             os: windows-latest
             package: win
             exe_suffix: ".exe"
-            cmake_extra: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+            cmake_extra: "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl"
             allow_failure: false
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure }}
@@ -41,6 +41,10 @@ jobs:
 
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
+
+      - name: Setup MSVC
+        if: ${{ runner.os == 'Windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install SDL2 on Linux
         if: ${{ runner.os == 'Linux' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ if(HASCIICAM_ENABLE_GUI AND HASCIICAM_WITH_SDL)
       third_party/imgui/backends
       src/gui
     )
+    target_include_directories(aalib PRIVATE src/gui)
     target_compile_definitions(hasciicam_core PRIVATE HASCIICAM_ENABLE_GUI=1)
     target_compile_definitions(aalib PRIVATE HASCIICAM_ENABLE_GUI=1)
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,14 +172,12 @@ if(HASCIICAM_ENABLE_GUI AND HASCIICAM_WITH_SDL)
       third_party/imgui/backends/imgui_impl_sdlrenderer2.cpp
     )
     list(APPEND HASCIICAM_GUI_SOURCES src/gui/gui_overlay.cpp)
-    target_sources(hasciicam_core PRIVATE ${HASCIICAM_GUI_SOURCES} ${HASCIICAM_IMGUI_SOURCES})
-    target_include_directories(hasciicam_core PRIVATE
+    target_sources(aalib PRIVATE ${HASCIICAM_GUI_SOURCES} ${HASCIICAM_IMGUI_SOURCES})
+    target_include_directories(aalib PRIVATE
       third_party/imgui
       third_party/imgui/backends
       src/gui
     )
-    target_include_directories(aalib PRIVATE src/gui)
-    target_compile_definitions(hasciicam_core PRIVATE HASCIICAM_ENABLE_GUI=1)
     target_compile_definitions(aalib PRIVATE HASCIICAM_ENABLE_GUI=1)
   else()
     message(STATUS "HASCIICAM_ENABLE_GUI requested but third_party/imgui not found; GUI disabled")
@@ -291,7 +289,6 @@ if(HASCIICAM_ENABLE_TESTS)
 
   add_executable(test_render_font
     tests/test_render_font.c
-    src/render/render_font.c
   )
   target_include_directories(test_render_font PRIVATE src/render third_party/aalib)
   target_link_libraries(test_render_font PRIVATE aalib)
@@ -304,7 +301,6 @@ if(HASCIICAM_ENABLE_TESTS)
   add_executable(test_app_config
     tests/test_app_config.c
     src/app/app_config.c
-    src/render/render_font.c
     src/app/tomlc17/tomlc17.c
   )
   target_include_directories(test_app_config PRIVATE src/app src/render third_party/aalib)

--- a/cmake/HasciiCamSources.cmake
+++ b/cmake/HasciiCamSources.cmake
@@ -47,6 +47,7 @@ set(HASCIICAM_AALIB_SOURCES
     third_party/aalib/fontx13b.c
     third_party/aalib/fontx13.c
     third_party/aalib/fontx16.c
+    src/render/render_font.c
 )
 
 set(HASCIICAM_APP_SOURCES
@@ -67,7 +68,6 @@ set(HASCIICAM_OUTPUT_SOURCES
 )
 
 set(HASCIICAM_RENDER_SOURCES
-    src/render/render_font.c
     src/render/render_session.c
 )
 

--- a/src/display/display_size.c
+++ b/src/display/display_size.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 
 #if defined(SDL_DRIVER)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 
 int hasciicam_display_size_detect_primary(int *width, int *height) {

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -193,7 +193,7 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
         state->mirror_y = mirror_y ? 1 : 0;
     ImGui::Text("Size: %dx%d", state->capture_width, state->capture_height);
     ImGui::Text("Stride: %d bytes", state->capture_stride_bytes);
-    ImGui::Text("Pixel format: %d", (int)state->capture_pixel_format);
+    ImGui::Text("Pixel format: %d", (int)state->pixel_format);
     ImGui::EndGroup();
     if (g_preview_texture != NULL && state->preview_width > 0 && state->preview_height > 0) {
         float aspect_w = (float)state->preview_width;

--- a/src/gui/gui_overlay.h
+++ b/src/gui/gui_overlay.h
@@ -1,7 +1,7 @@
 #ifndef HASCIICAM_GUI_OVERLAY_H
 #define HASCIICAM_GUI_OVERLAY_H
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "gui_state.h"
 
 #ifdef __cplusplus

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -93,7 +93,7 @@ void hasciicam_gui_state_set_capture_info(hasciicam_gui_state *state, const capt
     state->capture_width = info->width;
     state->capture_height = info->height;
     state->capture_stride_bytes = info->stride_bytes;
-    state->capture_pixel_format = info->pixel_format;
+    state->pixel_format = info->pixel_format;
 }
 
 void hasciicam_gui_state_set_capture_controls(hasciicam_gui_state *state,

--- a/src/gui/gui_state.h
+++ b/src/gui/gui_state.h
@@ -26,7 +26,7 @@ typedef struct hasciicam_gui_state {
     int capture_width;
     int capture_height;
     int capture_stride_bytes;
-    capture_pixel_format capture_pixel_format;
+    capture_pixel_format pixel_format;
     capture_control_desc capture_controls[CAPTURE_MAX_CONTROLS];
     int capture_control_count;
     int capture_control_change_requested;

--- a/third_party/aalib/aasdl.c
+++ b/third_party/aalib/aasdl.c
@@ -4,11 +4,11 @@
 #include <signal.h>
 
 #ifdef SDL_DRIVER
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "aalib.h"
 #include "aaint.h"
 #include "aasdlint.h"
-#include "../gui/gui_bridge.h"
+#include "gui_bridge.h"
 #include "../render/render_font.h"
 #if defined(HASCIICAM_ENABLE_GUI)
 #include "../gui/gui_overlay.h"

--- a/third_party/aalib/aasdlint.h
+++ b/third_party/aalib/aasdlint.h
@@ -1,7 +1,7 @@
 #ifndef __AASDLINT_H__
 #define __AASDLINT_H__
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 struct hasciicam_gui_state;
 


### PR DESCRIPTION
## Summary
- force Windows CI onto MSVC when using the vcpkg x64-windows SDL2 package
- normalize SDL includes to the target-provided `SDL.h` form
- add the GUI include path for the AA-lib SDL driver
- avoid a C++ name collision in GUI capture state

## Verification
- MSVC + vcpkg SDL configure/build succeeded locally
- `ctest --test-dir build-vcpkg-check --output-on-failure` passed 23/23, including `visual_sdl`
- no-SDL MSVC configure/build/test passed 22/22
- `git diff --check` passed