### PR TITLE
fix: restore foreground default and SDL AA dimming

### DIFF
--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -120,6 +120,10 @@ Specifies contrast level for the aa_render, from 0 to 100. Default is \fB4\fP.
 .IP "-g --aagamma"
 Specifies gamma correction level for the aa_render, from 0 to 100. Default is \fB3\fP.
 .B
+.IP "--aa-dimmer"
+Controls whether live SDL output uses AA-lib dim and bold attributes to render darker and brighter glyph tones.
+Accepted values are \fBon\fP and \fBoff\fP. Default is \fBon\fP.
+.B
 .IP "-I --invert"
 Invert and render the resulting negative ascii.
 .B
@@ -160,7 +164,7 @@ Canonical keys:
 .br
 \fBquiet mode device input pixel_size char_size output_file aa_driver daemon\fP
 .br
-\fBfont_size font_face refresh aa_bright aa_contrast aa_gamma invert\fP
+\fBfont_size font_face refresh aa_bright aa_contrast aa_gamma aa_dimmer invert\fP
 .br
 \fBbackground foreground font uid gid frames sdl_renderer sdl_vsync fullscreen mirror\fP
 .SH CONFIG FILES

--- a/docs/hasciicam.1
+++ b/docs/hasciicam.1
@@ -127,7 +127,7 @@ Invert and render the resulting negative ascii.
 Specifies the background color to be used in the form of a \fIhex RGB triplet\fR (without the leading #). Default is \fB000000\fP for black (only useful when in \fBhtml\fP mode).
 .B
 .IP "-F --foreground"
-Specifies the foreground color to be used in the form of a \fIhex RGB triplet\fR (without the leading #). Default is \fB00FF00\fP for green (only useful when in \fBhtml\fP mode).
+Specifies the foreground color to be used in the form of a \fIhex RGB triplet\fR (without the leading #). Default is \fBFFFFFF\fP for white.
 .SH EXAMPLES
 .B hasciicam -m html -o watchme.html
 .br

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -43,6 +43,7 @@ rendering options:
  -b --aabright     ascii brightness          - default 60
  -c --aacontrast   ascii contrast            - default 4
  -g --aagamma      ascii gamma               - default 3
+    --aa-dimmer    on|off                    - default on
  -I --invert       invert colors             - default off
  -B --background   background color (hex)    - default 000000
  -F --foreground   foreground color (hex)    - default FFFFFF

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -45,7 +45,7 @@ rendering options:
  -g --aagamma      ascii gamma               - default 3
  -I --invert       invert colors             - default off
  -B --background   background color (hex)    - default 000000
- -F --foreground   foreground color (hex)    - default 00FF00
+ -F --foreground   foreground color (hex)    - default FFFFFF
  ```
 
 ## Build From Source

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -114,7 +114,7 @@ static const char *help_text =
     " -g --aagamma      ascii gamma               - default 3\n"
     " -I --invert       invert colors             - default off\n"
     " -B --background   background color (hex)    - default 000000\n"
-    " -F --foreground   foreground color (hex)    - default 00FF00\n";
+    " -F --foreground   foreground color (hex)    - default FFFFFF\n";
 
 static const config_key_desc config_keys[] = {
     {"show_help", CONFIG_VALUE_BOOL, 0, 0},
@@ -772,7 +772,7 @@ void hasciicam_config_init_defaults(hasciicam_config *cfg) {
 #endif
 
     strcpy(cfg->background, "000000");
-    strcpy(cfg->foreground, "00FF00");
+    strcpy(cfg->foreground, "FFFFFF");
     strcpy(cfg->fontface, "courier");
     strcpy(cfg->font, hasciicam_font_default_name());
     strcpy(cfg->aadriver, "");

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -53,6 +53,7 @@ static const struct option long_options[] = {
     {"mirror", required_argument, NULL, 1006},
     {"config", required_argument, NULL, 1007},
     {"font", required_argument, NULL, 1008},
+    {"aa-dimmer", required_argument, NULL, 1009},
     {"help", no_argument, NULL, 'h'},
     {"aahelp", no_argument, NULL, 'H'},
     {"version", no_argument, NULL, 'v'},
@@ -112,6 +113,7 @@ static const char *help_text =
     " -b --aabright     ascii brightness          - default 60\n"
     " -c --aacontrast   ascii contrast            - default 4\n"
     " -g --aagamma      ascii gamma               - default 3\n"
+    "    --aa-dimmer    on|off                    - default on\n"
     " -I --invert       invert colors             - default off\n"
     " -B --background   background color (hex)    - default 000000\n"
     " -F --foreground   foreground color (hex)    - default FFFFFF\n";
@@ -137,6 +139,7 @@ static const config_key_desc config_keys[] = {
     {"aa_bright", CONFIG_VALUE_INT, 1, 1},
     {"aa_contrast", CONFIG_VALUE_INT, 1, 1},
     {"aa_gamma", CONFIG_VALUE_INT, 1, 1},
+    {"aa_dimmer", CONFIG_VALUE_BOOL, 1, 1},
     {"invert", CONFIG_VALUE_BOOL, 1, 1},
     {"background", CONFIG_VALUE_STRING, 1, 1},
     {"foreground", CONFIG_VALUE_STRING, 1, 1},
@@ -488,6 +491,13 @@ static int set_config_value(hasciicam_config *cfg,
         }
         return 1;
     }
+    if (strcmp(key, "aa_dimmer") == 0) {
+        if (!parse_bool_value(value, &cfg->aa_dimmer)) {
+            set_errorf(err, err_size, "invalid value for %s", key);
+            return 0;
+        }
+        return 1;
+    }
     if (strcmp(key, "invert") == 0) {
         if (!parse_bool_value(value, &cfg->invert)) {
             set_errorf(err, err_size, "invalid value for %s", key);
@@ -663,6 +673,11 @@ static int config_value_as_string(const hasciicam_config *cfg,
         *out_is_quoted = 0;
         return 1;
     }
+    if (strcmp(key, "aa_dimmer") == 0) {
+        snprintf(out, out_size, "%s", cfg->aa_dimmer ? "true" : "false");
+        *out_is_quoted = 0;
+        return 1;
+    }
     if (strcmp(key, "invert") == 0) {
         snprintf(out, out_size, "%s", cfg->invert ? "true" : "false");
         *out_is_quoted = 0;
@@ -785,6 +800,7 @@ void hasciicam_config_init_defaults(hasciicam_config *cfg) {
     cfg->aa_bright = 60;
     cfg->aa_contrast = 4;
     cfg->aa_gamma = 3;
+    cfg->aa_dimmer = 1;
     cfg->fontsize = 1;
     cfg->linespace = 5;
     cfg->uid = -1;
@@ -1093,6 +1109,12 @@ void hasciicam_config_parse(hasciicam_config *cfg,
                 exit(0);
             }
             if (!set_config_value(cfg, "font", optarg, env_err, sizeof(env_err))) {
+                fprintf(stderr, "!! %s\n", env_err);
+                exit(1);
+            }
+            break;
+        case 1009:
+            if (!set_config_value(cfg, "aa_dimmer", optarg, env_err, sizeof(env_err))) {
                 fprintf(stderr, "!! %s\n", env_err);
                 exit(1);
             }

--- a/src/app/app_config.h
+++ b/src/app/app_config.h
@@ -19,6 +19,7 @@ typedef struct hasciicam_config {
     int aa_bright;
     int aa_contrast;
     int aa_gamma;
+    int aa_dimmer;
     int fontsize;
     int linespace;
     int size_w;

--- a/src/gui/gui_bridge.h
+++ b/src/gui/gui_bridge.h
@@ -9,7 +9,10 @@ extern "C" {
 #endif
 
 int hasciicam_sdl_set_gui_state(aa_context *context, hasciicam_gui_state *state);
-int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foreground_rgb, unsigned int background_rgb);
+int hasciicam_sdl_set_runtime_colors(aa_context *context,
+                                     unsigned int foreground_rgb,
+                                     unsigned int background_rgb,
+                                     int aa_dimmer);
 int hasciicam_sdl_set_runtime_font(aa_context *context, const char *font_short_name);
 
 #ifdef __cplusplus

--- a/src/gui/gui_bridge_stub.c
+++ b/src/gui/gui_bridge_stub.c
@@ -8,10 +8,14 @@ int hasciicam_sdl_set_gui_state(aa_context *context, hasciicam_gui_state *state)
     return 0;
 }
 
-int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foreground_rgb, unsigned int background_rgb) {
+int hasciicam_sdl_set_runtime_colors(aa_context *context,
+                                     unsigned int foreground_rgb,
+                                     unsigned int background_rgb,
+                                     int aa_dimmer) {
     (void)context;
     (void)foreground_rgb;
     (void)background_rgb;
+    (void)aa_dimmer;
     return 0;
 }
 

--- a/src/gui/gui_overlay.cpp
+++ b/src/gui/gui_overlay.cpp
@@ -124,6 +124,7 @@ int hasciicam_gui_overlay_process_event(const SDL_Event *event) {
 void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     float fg[3];
     float bg[3];
+    bool dimmer;
     bool invert;
     bool mirror_x;
     bool mirror_y;
@@ -140,6 +141,9 @@ void hasciicam_gui_overlay_draw(hasciicam_gui_state *state) {
     ImGui::SliderInt("Brightness", &state->aa_bright, 0, 255);
     ImGui::SliderInt("Contrast", &state->aa_contrast, 0, 127);
     ImGui::SliderFloat("Gamma", &state->aa_gamma, 0.5f, 4.0f, "%.2f");
+    dimmer = state->aa_dimmer != 0;
+    if (ImGui::Checkbox("Dim attributes", &dimmer))
+        state->aa_dimmer = dimmer ? 1 : 0;
     invert = state->invert != 0;
     if (ImGui::Checkbox("Invert", &invert))
         state->invert = invert ? 1 : 0;

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -53,6 +53,7 @@ void hasciicam_gui_state_init(hasciicam_gui_state *state, const hasciicam_config
     state->aa_bright = cfg->aa_bright;
     state->aa_contrast = cfg->aa_contrast;
     state->aa_gamma = (float)cfg->aa_gamma;
+    state->aa_dimmer = cfg->aa_dimmer ? 1 : 0;
     state->invert = cfg->invert ? 1 : 0;
     state->mirror_x = cfg->mirror_x ? 1 : 0;
     state->mirror_y = cfg->mirror_y ? 1 : 0;
@@ -78,6 +79,7 @@ void hasciicam_gui_state_copy_to_config(const hasciicam_gui_state *state, hascii
     cfg->aa_bright = state->aa_bright;
     cfg->aa_contrast = state->aa_contrast;
     cfg->aa_gamma = (int)(state->aa_gamma + 0.5f);
+    cfg->aa_dimmer = state->aa_dimmer ? 1 : 0;
     cfg->invert = state->invert ? 1 : 0;
     cfg->mirror_x = state->mirror_x ? 1 : 0;
     cfg->mirror_y = state->mirror_y ? 1 : 0;

--- a/src/gui/gui_state.c
+++ b/src/gui/gui_state.c
@@ -43,7 +43,7 @@ void hasciicam_gui_format_rgb_hex(unsigned int rgb, char *out, size_t out_size) 
 }
 
 void hasciicam_gui_state_init(hasciicam_gui_state *state, const hasciicam_config *cfg) {
-    unsigned int fg = 0x00FF00u;
+    unsigned int fg = 0xFFFFFFu;
     unsigned int bg = 0x000000u;
 
     if (state == NULL || cfg == NULL)
@@ -60,7 +60,7 @@ void hasciicam_gui_state_init(hasciicam_gui_state *state, const hasciicam_config
     if (hasciicam_gui_parse_rgb_hex(cfg->foreground, &fg))
         state->foreground_rgb = fg;
     else
-        state->foreground_rgb = 0x00FF00u;
+        state->foreground_rgb = 0xFFFFFFu;
     if (hasciicam_gui_parse_rgb_hex(cfg->background, &bg))
         state->background_rgb = bg;
     else

--- a/src/gui/gui_state.h
+++ b/src/gui/gui_state.h
@@ -12,6 +12,7 @@ typedef struct hasciicam_gui_state {
     int aa_bright;
     int aa_contrast;
     float aa_gamma;
+    int aa_dimmer;
     int invert;
 
     int mirror_x;

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -522,7 +522,8 @@ main (int argc, char **argv) {
       int copy_size;
 
       framenum = 0;
-      hasciicam_gui_state_update_preview(&gui_state, gray_frame, ascii_width, ascii_height);
+      if (gui_state.visible)
+        hasciicam_gui_state_update_preview(&gui_state, gray_frame, ascii_width, ascii_height);
       dest_size = aa_imgwidth(render_session.context) * aa_imgheight(render_session.context);
       copy_size = (gray_size < dest_size) ? gray_size : dest_size;
       if (copy_size > 0) {

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -370,7 +370,8 @@ main (int argc, char **argv) {
   hasciicam_gui_state_set_capture_controls(&gui_state, control_descs, control_count);
   hasciicam_sdl_set_runtime_colors(render_session.context,
                                    gui_state.foreground_rgb,
-                                   gui_state.background_rgb);
+                                   gui_state.background_rgb,
+                                   gui_state.aa_dimmer);
   hasciicam_sdl_set_gui_state(render_session.context, &gui_state);
   // those are left to be setted by aalib options
   //  ascii_rndparms->dither = AA_FLOYD_S;
@@ -506,7 +507,8 @@ main (int argc, char **argv) {
     }
     hasciicam_sdl_set_runtime_colors(render_session.context,
                                      gui_state.foreground_rgb,
-                                     gui_state.background_rgb);
+                                     gui_state.background_rgb,
+                                     gui_state.aa_dimmer);
 
     if (!hasciicam_session_step(&session, aa_imgwidth(render_session.context),
                                 aa_imgheight(render_session.context),

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -43,7 +43,7 @@ static void clear_test_env(void) {
         "show_help", "show_aahelp", "show_version",
         "quiet", "mode", "device", "input", "size", "pixel_size", "char_size",
         "output_file", "aa_driver", "daemon", "font_size", "font_face", "font",
-        "refresh", "aa_bright", "aa_contrast", "aa_gamma", "invert",
+        "refresh", "aa_bright", "aa_contrast", "aa_gamma", "aa_dimmer", "invert",
         "background", "foreground", "uid", "gid", "frames",
         "sdl_renderer", "sdl_vsync", "fullscreen", "mirror"
     };
@@ -63,6 +63,7 @@ static void test_env_load(void) {
     set_env_var("font_size", "3");
     set_env_var("font", "vga8");
     set_env_var("invert", "true");
+    set_env_var("aa_dimmer", "off");
     set_env_var("sdl_vsync", "off");
     set_env_var("char_size", "80x25");
 
@@ -73,6 +74,7 @@ static void test_env_load(void) {
     expect_true(cfg.fontsize == 3, "font_size should be 3");
     expect_true(strcmp(cfg.font, "vga8") == 0, "font should be vga8");
     expect_true(cfg.invert == 1, "invert should be true");
+    expect_true(cfg.aa_dimmer == 0, "aa_dimmer should be off");
     expect_true(cfg.sdl_vsync == 0, "sdl_vsync should be off");
     expect_true(cfg.size_intent == HASCIICAM_SIZE_CHARS, "char_size should set char intent");
     expect_true(cfg.size_w == 80 && cfg.size_h == 25, "char_size should parse 80x25");
@@ -86,6 +88,7 @@ static void test_defaults(void) {
     hasciicam_config_init_defaults(&cfg);
     expect_true(strcmp(cfg.background, "000000") == 0, "default background should be black");
     expect_true(strcmp(cfg.foreground, "FFFFFF") == 0, "default foreground should be white");
+    expect_true(cfg.aa_dimmer == 1, "default aa_dimmer should be on");
 }
 
 static void test_cli_overrides_env(void) {
@@ -195,6 +198,7 @@ static void test_toml_roundtrip(void) {
     strcpy(cfg.aafile, "roundtrip.asc");
     cfg.sdl_vsync = 1;
     cfg.invert = 1;
+    cfg.aa_dimmer = 0;
     cfg.size_intent = HASCIICAM_SIZE_CHARS;
     cfg.size_w = 90;
     cfg.size_h = 30;
@@ -209,6 +213,7 @@ static void test_toml_roundtrip(void) {
     expect_true(strcmp(loaded.aafile, "roundtrip.asc") == 0, "roundtrip output_file should match");
     expect_true(loaded.sdl_vsync == 1, "roundtrip sdl_vsync should be on");
     expect_true(loaded.invert == 1, "roundtrip invert should match");
+    expect_true(loaded.aa_dimmer == 0, "roundtrip aa_dimmer should match");
     expect_true(loaded.size_intent == HASCIICAM_SIZE_CHARS, "roundtrip size intent should be chars");
     expect_true(loaded.size_w == 90 && loaded.size_h == 30, "roundtrip size should match");
     expect_true(strcmp(loaded.font, "vga8") == 0, "roundtrip font should match");

--- a/tests/test_app_config.c
+++ b/tests/test_app_config.c
@@ -80,6 +80,14 @@ static void test_env_load(void) {
     clear_test_env();
 }
 
+static void test_defaults(void) {
+    hasciicam_config cfg;
+
+    hasciicam_config_init_defaults(&cfg);
+    expect_true(strcmp(cfg.background, "000000") == 0, "default background should be black");
+    expect_true(strcmp(cfg.foreground, "FFFFFF") == 0, "default foreground should be white");
+}
+
 static void test_cli_overrides_env(void) {
     hasciicam_config cfg;
     char *argv[] = {
@@ -288,6 +296,7 @@ static void test_env_size_key_ignored(void) {
 }
 
 int main(void) {
+    test_defaults();
     test_env_load();
     test_cli_overrides_env();
     test_default_toml_load();

--- a/tests/test_gui_state.c
+++ b/tests/test_gui_state.c
@@ -24,6 +24,7 @@ int main(void) {
     cfg.aa_bright = 77;
     cfg.aa_contrast = 8;
     cfg.aa_gamma = 2;
+    cfg.aa_dimmer = 1;
     cfg.invert = 1;
     cfg.mirror_x = 1;
     cfg.mirror_y = 0;
@@ -33,6 +34,7 @@ int main(void) {
     if (!expect_true(state.aa_bright == 77, "bright init failed")) return 1;
     if (!expect_true(state.aa_contrast == 8, "contrast init failed")) return 1;
     if (!expect_true((int)state.aa_gamma == 2, "gamma init failed")) return 1;
+    if (!expect_true(state.aa_dimmer == 1, "aa_dimmer init failed")) return 1;
     if (!expect_true(state.invert == 1, "invert init failed")) return 1;
     if (!expect_true(state.mirror_x == 1 && state.mirror_y == 0, "mirror init failed")) return 1;
     if (!expect_true(state.background_rgb == 0x123456u, "background parse failed")) return 1;
@@ -50,6 +52,7 @@ int main(void) {
     state.aa_bright = 66;
     state.aa_contrast = 7;
     state.aa_gamma = 3.4f;
+    state.aa_dimmer = 0;
     state.invert = 0;
     state.mirror_x = 0;
     state.mirror_y = 1;
@@ -61,6 +64,7 @@ int main(void) {
     if (!expect_true(cfg.aa_bright == 66, "bright copy failed")) return 1;
     if (!expect_true(cfg.aa_contrast == 7, "contrast copy failed")) return 1;
     if (!expect_true(cfg.aa_gamma == 3, "gamma copy failed")) return 1;
+    if (!expect_true(cfg.aa_dimmer == 0, "aa_dimmer copy failed")) return 1;
     if (!expect_true(cfg.invert == 0, "invert copy failed")) return 1;
     if (!expect_true(cfg.mirror_x == 0 && cfg.mirror_y == 1, "mirror copy failed")) return 1;
     if (!expect_true(strcmp(cfg.background, "0000FF") == 0, "background copy failed")) return 1;

--- a/third_party/aalib/aasdl.c
+++ b/third_party/aalib/aasdl.c
@@ -216,6 +216,8 @@ static void SDL_process_events(struct sdldriverdata *d)
             d != NULL && d->gui_ready) {
             if (!hasciicam_gui_overlay_wants_mouse()) {
                 d->gui_visible = d->gui_visible ? 0 : 1;
+                if (d->gui_state != NULL)
+                    d->gui_state->visible = d->gui_visible;
             }
             continue;
         }
@@ -794,6 +796,8 @@ int hasciicam_sdl_set_gui_state(aa_context *context, struct hasciicam_gui_state 
         return 0;
     d = (struct sdldriverdata *)context->driverdata;
     d->gui_state = state;
+    if (state != NULL)
+        state->visible = d->gui_visible;
 #if defined(HASCIICAM_ENABLE_GUI)
     if (!d->gui_ready) {
         d->gui_ready = hasciicam_gui_overlay_init(d->window, d->renderer) ? 1 : 0;

--- a/third_party/aalib/aasdl.c
+++ b/third_party/aalib/aasdl.c
@@ -26,7 +26,8 @@ static void SDL_process_events(struct sdldriverdata *d);
 static void SDL_set_fullscreen(struct sdldriverdata *d, int enable);
 static void SDL_apply_runtime_colors(struct sdldriverdata *d,
                                      unsigned int foreground_rgb,
-                                     unsigned int background_rgb);
+                                     unsigned int background_rgb,
+                                     int aa_dimmer);
 
 static int SDL_env_is(const char *value, const char *expected)
 {
@@ -703,6 +704,25 @@ static void SDL_flush(aa_context *c)
             
             int fg_color = d->normal_color;
             int bg_color = d->black_color;
+            switch (attr) {
+            case AA_DIM:
+                fg_color = d->dim_color;
+                break;
+            case AA_BOLD:
+            case AA_BOLDFONT:
+                fg_color = d->bold_color;
+                break;
+            case AA_SPECIAL:
+                fg_color = d->special_color;
+                break;
+            case AA_REVERSE:
+                fg_color = d->black_color;
+                bg_color = d->normal_color;
+                break;
+            default:
+                fg_color = d->normal_color;
+                break;
+            }
             
             if (ch != d->previoust[pos] || attr != d->previousa[pos]) {
                 SDL_stream_draw_char(d, ch, x, y, fg_color, bg_color);
@@ -773,18 +793,52 @@ static unsigned int clamp_rgb24(unsigned int rgb) {
     return rgb & 0x00FFFFFFu;
 }
 
+static unsigned int scale_rgb24(unsigned int rgb, unsigned int numerator, unsigned int denominator) {
+    unsigned int r;
+    unsigned int g;
+    unsigned int b;
+    if (denominator == 0)
+        return clamp_rgb24(rgb);
+    rgb = clamp_rgb24(rgb);
+    r = (((rgb >> 16) & 0xFFu) * numerator) / denominator;
+    g = (((rgb >> 8) & 0xFFu) * numerator) / denominator;
+    b = ((rgb & 0xFFu) * numerator) / denominator;
+    if (r > 255u) r = 255u;
+    if (g > 255u) g = 255u;
+    if (b > 255u) b = 255u;
+    return (r << 16) | (g << 8) | b;
+}
+
 static void SDL_apply_runtime_colors(struct sdldriverdata *d,
                                      unsigned int foreground_rgb,
-                                     unsigned int background_rgb) {
+                                     unsigned int background_rgb,
+                                     int aa_dimmer) {
     if (d == NULL)
         return;
     foreground_rgb = clamp_rgb24(foreground_rgb);
     background_rgb = clamp_rgb24(background_rgb);
+    aa_dimmer = aa_dimmer ? 1 : 0;
+    if (d->runtime_colors_initialized &&
+        d->runtime_foreground_color == (int)foreground_rgb &&
+        d->runtime_background_color == (int)background_rgb &&
+        d->runtime_aa_dimmer == aa_dimmer) {
+        return;
+    }
+    d->runtime_foreground_color = (int)foreground_rgb;
+    d->runtime_background_color = (int)background_rgb;
+    d->runtime_aa_dimmer = aa_dimmer;
+    d->runtime_colors_initialized = 1;
     d->normal_color = (int)foreground_rgb;
     d->black_color = (int)background_rgb;
-    d->dim_color = d->normal_color;
-    d->bold_color = d->normal_color;
-    d->special_color = d->normal_color;
+    if (aa_dimmer) {
+        d->dim_color = (int)scale_rgb24(foreground_rgb, 58u, 100u);
+        d->bold_color = (int)foreground_rgb;
+        d->special_color = (int)foreground_rgb;
+    } else {
+        d->dim_color = d->normal_color;
+        d->bold_color = d->normal_color;
+        d->special_color = d->normal_color;
+    }
     d->force_clear = 1;
 }
 
@@ -808,14 +862,17 @@ int hasciicam_sdl_set_gui_state(aa_context *context, struct hasciicam_gui_state 
     return d->gui_ready;
 }
 
-int hasciicam_sdl_set_runtime_colors(aa_context *context, unsigned int foreground_rgb, unsigned int background_rgb) {
+int hasciicam_sdl_set_runtime_colors(aa_context *context,
+                                     unsigned int foreground_rgb,
+                                     unsigned int background_rgb,
+                                     int aa_dimmer) {
     struct sdldriverdata *d;
     if (context == NULL || context->driverdata == NULL)
         return 0;
     if (context->driver != &SDL_d)
         return 0;
     d = (struct sdldriverdata *)context->driverdata;
-    SDL_apply_runtime_colors(d, foreground_rgb, background_rgb);
+    SDL_apply_runtime_colors(d, foreground_rgb, background_rgb, aa_dimmer);
     return 1;
 }
 

--- a/third_party/aalib/aasdlint.h
+++ b/third_party/aalib/aasdlint.h
@@ -28,6 +28,10 @@ struct sdldriverdata {
     int normal_color;
     int bold_color;
     int special_color;
+    int runtime_foreground_color;
+    int runtime_background_color;
+    int runtime_aa_dimmer;
+    int runtime_colors_initialized;
     
     int current_attr;
     int inverted;


### PR DESCRIPTION
## Summary
- restore the compiled foreground default to white (`FFFFFF`)
- restore SDL rendering of AA-lib dim/bold attributes for darker/brighter glyph tones
- add `aa_dimmer` config/env/TOML support and `--aa-dimmer on|off`, defaulting on
- add a live GUI `Dim attributes` switch
- skip GUI preview buffer updates while the SDL overlay is hidden
- update help/docs and config/GUI tests

## Why
The green value came from the config extraction path: `foreground` defaulted to `00FF00`, historically documented for HTML output, and the newer SDL live color plumbing then applied that same config value to live SDL.

The SDL runtime color path also flattened AA-lib attributes into one foreground color, so `AA_DIM` stopped producing darker surfaces. With `aa_dimmer` enabled, SDL now maps AA attributes to dim/normal/bold colors again. With it disabled, output uses a flat foreground color.

The preview optimization keeps SDL's private overlay visibility in sync with `hasciicam_gui_state.visible`, then avoids copying the grayscale preview frame unless the overlay is open. Normal rendering still copies the frame into AA-lib every render hop.

## Verification
- `git diff --check`
- MSVC no-SDL configure/build/test: `ctest --test-dir build-dimmer-nosdl --output-on-failure` passed 22/22
- MSVC + vcpkg SDL configure/build/test with dummy SDL video and software renderer: `ctest --test-dir build-dimmer-sdl --output-on-failure` passed 23/23, including `visual_sdl`
- CLI smoke: `hasciicam.exe -d synthetic:// --frames 1 -m text --aa-dimmer off -o ...` succeeded
- Help output includes `--aa-dimmer`