### PR TITLE
fix(capture/avfoundation): seed frame geometry from activeFormat before start()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,28 @@ if(POLICY CMP0091)
 endif()
 project(hasciicam VERSION 2.0 LANGUAGES C CXX)
 
+# Bump the literal above at each release. When building from a git checkout,
+# HASCIICAM_VERSION_STRING is overridden with `git describe` output so builds
+# off a tag report the exact release and builds off a branch report
+# "<tag>-<n>-g<sha>[-dirty]". Tarball builds fall back to PROJECT_VERSION.
+set(HASCIICAM_VERSION_STRING "${PROJECT_VERSION}")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  find_package(Git QUIET)
+  if(GIT_FOUND)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --tags --match "v*" --always --dirty
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE HASCIICAM_GIT_DESCRIBE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+      RESULT_VARIABLE HASCIICAM_GIT_RC)
+    if(HASCIICAM_GIT_RC EQUAL 0 AND HASCIICAM_GIT_DESCRIBE)
+      string(REGEX REPLACE "^v" "" HASCIICAM_VERSION_STRING "${HASCIICAM_GIT_DESCRIBE}")
+    endif()
+  endif()
+endif()
+message(STATUS "hasciicam version string: ${HASCIICAM_VERSION_STRING}")
+
 if(APPLE)
   enable_language(OBJCXX)
 endif()
@@ -113,7 +135,7 @@ endif()
 # Create aalib static library
 add_library(aalib STATIC ${HASCIICAM_AALIB_SOURCES})
 target_include_directories(aalib PUBLIC third_party/aalib)
-target_compile_definitions(aalib PRIVATE HASCIICAM_APP_TITLE="hasciicam ${PROJECT_VERSION}")
+target_compile_definitions(aalib PRIVATE HASCIICAM_APP_TITLE="hasciicam ${HASCIICAM_VERSION_STRING}")
 if(WIN32)
     target_include_directories(aalib PUBLIC src/compat)
     target_compile_definitions(aalib PRIVATE _CRT_SECURE_NO_WARNINGS)
@@ -254,7 +276,7 @@ if(HASCIICAM_BUILD_CLI)
   add_executable(hasciicam src/hasciicam.c)
   target_compile_definitions(hasciicam PRIVATE
       PACKAGE="hasciicam"
-      VERSION="${PROJECT_VERSION}"
+      VERSION="${HASCIICAM_VERSION_STRING}"
   )
   if(WIN32)
       target_include_directories(hasciicam PRIVATE src/compat)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
-project(hasciicam VERSION 2.0 LANGUAGES C CXX)
+project(hasciicam VERSION 2.6.0 LANGUAGES C CXX)
 
 # Bump the literal above at each release. When building from a git checkout,
 # HASCIICAM_VERSION_STRING is overridden with `git describe` output so builds

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 PACKAGE := hasciicam
-VERSION ?= 2.0.0
+VERSION ?= 2.6.0
 
 CC ?= gcc
 CFLAGS ?= -O0 -ggdb

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ People who contributed to this project:
 - thomas pfau - ftp library
 - blended - wider webcam support
 - dan stowell - v4l2 api support
+- puria nafisi azizi - build/version wiring and macOS AVFoundation adapter
 
 Special thanks to:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ Common CMake options (all `-D<name>=ON|OFF`):
 - `HASCIICAM_ENABLE_GUI` — SDL live-mode ImGui overlay (default ON).
 - `HASCIICAM_ENABLE_VIRTUAL_CAMERA` — build the virtual webcam output.
 
+Versioning:
+
+- CMake takes the release base from `project(hasciicam VERSION ...)` in
+  `CMakeLists.txt` — bump it once per release (matching the git tag `vX.Y.Z`).
+- When building from a git checkout, the CLI banner is overridden with
+  `git describe --tags --match "v*" --always --dirty`, so tag builds report
+  the exact version and branch builds report `X.Y.Z-<n>-g<sha>[-dirty]`.
+- Tarball builds (no `.git`) fall back to the `project(VERSION ...)` literal.
+- Re-run `cmake -B build .` after fetching new tags to refresh the banner.
+
 Quick smoke test after building:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -19,19 +19,68 @@ plugin, java etc. (which was an issue, back in 2001 when it was done).
 
 # BUILD FROM SOURCE
 
-To compile the sourcecode use CMake
+Prerequisites:
+
+- A C/C++ toolchain (Clang or GCC on Unix, MSVC on Windows).
+- CMake 3.16+.
+- Optional runtime backends discovered at configure time: SDL2 (preferred live
+  display), ncurses (terminal live display), X11 (Linux only).
+- macOS uses the system AVFoundation for capture; Linux uses V4L2; Windows uses
+  Media Foundation with a DirectShow fallback (via vcpkg for SDL2).
+
+Standard build (uses whichever generator CMake picks by default — Unix Makefiles
+on Linux/macOS, Visual Studio on Windows):
+
 ```sh
 cmake -B build .
-cmake --build build
-cmake --install build
+cmake --build build -j
+cmake --install build    # optional; installs to CMAKE_INSTALL_PREFIX
 ```
 
-With presets (recommended for cross-platform maintenance):
+The build produces `build/hasciicam` (the CLI) and `build/libhasciicam_core.a`
+(the reusable core linked by host samples under `examples/`).
+
+Run the tests:
+
+```sh
+ctest --output-on-failure --test-dir build
+```
+
+With presets (recommended for cross-platform maintenance, requires Ninja):
+
 ```sh
 cmake --list-presets
-cmake --preset windows-vcpkg-ninja
+cmake --preset macos-ninja      # or linux-ninja, windows-vcpkg-ninja, wasm-emscripten
+cmake --build --preset macos-ninja
 ```
-Other presets are `linux-ninja`, `macos-ninja`, and `wasm-emscripten`.
+
+The available presets are `linux-ninja`, `macos-ninja`, `windows-vcpkg-ninja`,
+and `wasm-emscripten`. Install Ninja first (`brew install ninja`,
+`apt install ninja-build`, or `choco install ninja`).
+
+Common CMake options (all `-D<name>=ON|OFF`):
+
+- `HASCIICAM_BUILD_CLI` — build the `hasciicam` executable (default ON).
+- `HASCIICAM_ENABLE_TESTS` — build CTest targets (default ON).
+- `HASCIICAM_ENABLE_SDL`, `HASCIICAM_ENABLE_X11`, `HASCIICAM_ENABLE_CURSES` —
+  display backends; each is auto-disabled if its dependency is not found.
+- `HASCIICAM_ENABLE_CAPTURE_V4L2` / `_MF` / `_DSHOW` / `_AVFOUNDATION` —
+  capture backends per platform.
+- `HASCIICAM_ENABLE_GUI` — SDL live-mode ImGui overlay (default ON).
+- `HASCIICAM_ENABLE_VIRTUAL_CAMERA` — build the virtual webcam output.
+
+Quick smoke test after building:
+
+```sh
+./build/hasciicam -h                                   # CLI help
+./build/hasciicam -H                                   # CLI + AA-lib help
+./build/hasciicam -d synthetic:// --frames 2 -O stdout # no-camera pipeline test
+./build/hasciicam -O SDL                               # live ASCII from the default camera
+```
+
+On macOS, live mode triggers a Camera permission prompt on first run; grant it
+in *System Settings → Privacy & Security → Camera* for the terminal that
+launched `hasciicam`.
 
 ## On-Screen GUI (SDL Live Mode)
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -9,10 +9,9 @@ To see a brief list of command line options:
 ./hasciicam -h
 ```
 
-
 ```
-hasciicam 2.0 - (h)ascii 4 the masses! - https://ascii.dyne.org
-(c)2000-2025 RASTASOFT by Jaromil @ Dyne.org
+hasciicam 2.6.0 - (h)ascii 4 the masses! - https://ascii.dyne.org
+(c)2000-2026 RASTASOFT by Jaromil @ Dyne.org
 
 Usage: hasciicam [options] [rendering options] [aalib options]
 options:

--- a/src/app/app_config.c
+++ b/src/app/app_config.c
@@ -1319,7 +1319,7 @@ void hasciicam_config_parse(hasciicam_config *cfg,
     if (cfg->show_version) {
         fprintf(stderr,
                 "\n%s %s - (h)ascii 4 the masses! - https://ascii.dyne.org\n"
-                "(c)2000-2025 RASTASOFT by Jaromil @ Dyne.org\n\n",
+                "(c)2000-2026 RASTASOFT by Jaromil @ Dyne.org\n\n",
                 package, version);
         exit(0);
     }

--- a/src/capture/capture_avfoundation.mm
+++ b/src/capture/capture_avfoundation.mm
@@ -181,6 +181,15 @@ static int avf_start(capture_device *dev) {
     if (dev == NULL || dev->session == nil)
         return 0;
     [dev->session startRunning];
+    // Block for the first sample buffer: the render loop breaks on any
+    // failed read(), and AVFoundation typically delivers frame 0 several
+    // hundred ms after startRunning.
+    if (dev->delegate != nil) {
+        std::unique_lock<std::mutex> lock(dev->delegate->frame_mutex);
+        if (!dev->delegate->has_frame) {
+            dev->delegate->frame_ready.wait_for(lock, std::chrono::milliseconds(2000));
+        }
+    }
     return 1;
 }
 

--- a/src/capture/capture_avfoundation.mm
+++ b/src/capture/capture_avfoundation.mm
@@ -145,6 +145,21 @@ static int avf_open(capture_device **out, const capture_request *req) {
     dev->queue = dispatch_queue_create("org.dyne.hasciicam.avfoundation", DISPATCH_QUEUE_SERIAL);
     [dev->output setSampleBufferDelegate:dev->delegate queue:dev->queue];
 
+    // Seed geometry from activeFormat: describe() runs before start(), so
+    // the delegate hasn't received a frame yet and its width/height are 0.
+    if (device.activeFormat != nil) {
+        CMFormatDescriptionRef desc = device.activeFormat.formatDescription;
+        if (desc != NULL) {
+            CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions(desc);
+            if (dims.width > 0 && dims.height > 0) {
+                std::lock_guard<std::mutex> lock(dev->delegate->frame_mutex);
+                dev->delegate->frame_width = dims.width;
+                dev->delegate->frame_height = dims.height;
+                dev->delegate->frame_stride = dims.width * 4;
+            }
+        }
+    }
+
     *out = dev;
     return 1;
 }

--- a/src/hasciicam.c
+++ b/src/hasciicam.c
@@ -190,7 +190,7 @@ main (int argc, char **argv) {
       perror ("Couldn't install SIGINT handler"); exit (1); }
   fprintf(stderr,
           "\n%s %s - (h)ascii 4 the masses! - https://ascii.dyne.org\n"
-          "(c)2000-2025 RASTASOFT by Jaromil @ Dyne.org\n\n",
+          "(c)2000-2026 RASTASOFT by Jaromil @ Dyne.org\n\n",
           PACKAGE, VERSION);
 
   hasciicam_config_init_defaults(&appcfg);


### PR DESCRIPTION
- **fix(capture/avfoundation): seed frame geometry from activeFormat before start()**
- **fix(capture/avfoundation): wait up to 2s for first frame in avf_start**
- **docs(readme): rewrite BUILD FROM SOURCE section**
- **feat(cmake): derive CLI version from git describe with tarball fallback**
- **chore(release): 2.6.0**
- **chore(banner): bump copyright to 2026 and refresh usage-guide snippet**
